### PR TITLE
Installation failing on Jessie when datadog.conf doesn't exist.

### DIFF
--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -34,7 +34,6 @@ if [ -f /etc/debian_version ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$LI
           update-rc.d datadog-agent defaults
           adduser --system dd-agent --disabled-login --shell /bin/sh --no-create-home --quiet
           usermod -d /opt/datadog-agent dd-agent
-          set +e
       ;;
       abort-upgrade|abort-remove|abort-deconfigure)
       ;;
@@ -53,24 +52,28 @@ chown -R dd-agent:root ${LOG_DIR}
 chown root:root /etc/init.d/datadog-agent
 chown -R root:root /opt/datadog-agent
 
-if which chkconfig >/dev/null 2>&1; then
-  chkconfig --add datadog-agent
-fi
-
-MISSING_CONF_MSG="\033[34m\n* No /etc/dd-agent/datadog.conf file has been found.\033[0m"
-if which invoke-rc.d >/dev/null 2>&1; then
-    invoke-rc.d datadog-agent restart || echo "$MISSING_CONF_MSG"
+if which systemctl >/dev/null 2>&1; then
+    systemctl try-restart datadog-agent
 else
-    /etc/init.d/datadog-agent restart || echo "$MISSING_CONF_MSG"
-fi
-RETVAL=$?
-if [ $RETVAL -ne 0 ]; then
-    if [ $RETVAL -eq 3 ]; then
-        # No datadog.conf file is present. The user is probably following
-        # the step-by-step instructions and will add the config file next.
-        exit 0
+    if which chkconfig >/dev/null 2>&1; then
+        chkconfig --add datadog-agent
+    fi
+
+    set +e
+    if which invoke-rc.d >/dev/null 2>&1; then
+        invoke-rc.d datadog-agent restart 
     else
-        exit $RETVAL
+        /etc/init.d/datadog-agent restart 
+    fi
+    RETVAL=$?
+    if [ $RETVAL -ne 0 ]; then
+        if [ $RETVAL -eq 3 ]; then
+            # No datadog.conf file is present. The user is probably following
+            # the step-by-step instructions and will add the config file next.
+            exit 0
+        else
+            exit $RETVAL
+        fi
     fi
 fi
 

--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -57,14 +57,12 @@ if which chkconfig >/dev/null 2>&1; then
   chkconfig --add datadog-agent
 fi
 
-set +e
+MISSING_CONF_MSG="\033[34m\n* No /etc/dd-agent/datadog.conf file has been found.\033[0m"
 if which invoke-rc.d >/dev/null 2>&1; then
-    invoke-rc.d datadog-agent restart
+    invoke-rc.d datadog-agent restart || echo "$MISSING_CONF_MSG"
 else
-    /etc/init.d/datadog-agent restart
+    /etc/init.d/datadog-agent restart || echo "$MISSING_CONF_MSG"
 fi
-set -e
-
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then
     if [ $RETVAL -eq 3 ]; then

--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -57,11 +57,14 @@ if which chkconfig >/dev/null 2>&1; then
   chkconfig --add datadog-agent
 fi
 
+set +e
 if which invoke-rc.d >/dev/null 2>&1; then
     invoke-rc.d datadog-agent restart
 else
     /etc/init.d/datadog-agent restart
 fi
+set -e
+
 RETVAL=$?
 if [ $RETVAL -ne 0 ]; then
     if [ $RETVAL -eq 3 ]; then


### PR DESCRIPTION
We needed to add the set +e so that the deb post install script doesn't block th...e whole installation process if it fails because of a non-existing /etc/dd-agent/datadog.conf file.

My main concern is "why do we need to restart our agent here ??". And why was it working before as well because in the end it wasn't really related to systemd ?