### PR TITLE
Remove `Provides` from package metadata

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -21,10 +21,12 @@ description "Datadog Monitoring Agent
 "
 platform_in_iteration false
 
+# Note: this is to try to avoid issues when upgrading from an
+# old version of the agent which shipped also a datadog-agent-base
+# package.
 if Ohai['platform_family'] == 'rhel'
     replaces "datadog-agent-base < 5.0.0"
     replaces "datadog-agent-lib < 5.0.0"
-
 elsif Ohai['platform_family'] == 'debian'
     replaces "datadog-agent-base (<< 5.0.0)"
     replaces "datadog-agent-lib (<< 5.0.0)"
@@ -36,9 +38,6 @@ extra_package_file "/etc/dd-agent"
 extra_package_file "/usr/bin/dd-agent"
 extra_package_file "/usr/bin/dogstatsd"
 extra_package_file "/usr/bin/dd-forwarder"
-
-provides "datadog-agent-base"
-
 
 # creates required build directories
 dependency "preparation"


### PR DESCRIPTION
This is to avoid issues with yum which uninstalls `datadog-agent` when
running `yum remove datadog-agent-base` because `datadog-agent` provides
`datadog-agent-base`