### PR TITLE
Gohai should be added at the very end

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -47,7 +47,6 @@ dependency "preparation"
 
 # Agent dependencies
 dependency "boto"
-dependency "datadog-gohai"
 dependency "ntplib"
 dependency "procps-ng"
 dependency "pycrypto"
@@ -81,6 +80,7 @@ dependency "requests"
 dependency "snakebite"
 
 # Datadog agent
+dependency "datadog-gohai"
 dependency "datadog-agent"
 
 # version manifest file


### PR DESCRIPTION
So we can make sure to always build it without dirtying the cache.

See omnibus cache docs for details
https://github.com/chef/omnibus/blob/master/docs/Build%20Cache.md