### PR TITLE
[debian] do not stop the agent in preinst

### DIFF
--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -10,13 +10,6 @@ DISTRIBUTION=$(grep -Eo "(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon)" /etc/iss
 if [ "$DISTRIBUTION" != "Darwin" ]; then
   if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" == "Debian" ] || [ "$DISTRIBUTION" == "Ubuntu" ]; then
     set -e
-    if [ -f "/etc/init.d/datadog-agent" ]; then
-      if command -v invoke-rc.d >/dev/null 2>&1; then
-        invoke-rc.d datadog-agent stop || true
-      else
-        /etc/init.d/datadog-agent stop || true
-      fi
-    fi
 
     # Since we now package our own supervisor config, we no longer want
     # the old config to be loaded. Since supervisor automatically loads


### PR DESCRIPTION
As it is already stopped in `prerm`, see 6.6 of
https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html

It avoids stopping twice the agent:
<img width="624" alt="screen shot 2015-10-20 at 15 47 34" src="https://cloud.githubusercontent.com/assets/4912048/10609026/f9456cb4-7741-11e5-895c-6023f470b7dd.png">


Otherwise, if before a specific version we weren't stopping the agent in `prerm`, this PR should not be merged. I only searched back to the first commit (5.0 version) of this repo which contains the `stop` in `prerm`: https://github.com/DataDog/dd-agent-omnibus/blob/425bfb88bbd994a0ef05bc0cc10d0ceb9eff61d9/package-scripts/datadog-agent/prerm#L5-L9