### PR TITLE
Do NOT fail if /opt/datadog-agent does not exist

### DIFF
--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -34,7 +34,7 @@ if [ -f /etc/debian_version ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$LI
   # of https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html)
   # It is also here because version < 5.4 didn't delete .pyc,
   # so we need to be sure to clean them here (if a file is deleted for instance)
-  find /opt/datadog-agent -name '*.py[co]' -delete
+  find /opt/datadog-agent -name '*.py[co]' -type f -delete || true
 
   #DEBHELPER#
 

--- a/package-scripts/datadog-agent/prerm
+++ b/package-scripts/datadog-agent/prerm
@@ -29,7 +29,7 @@ else
 fi
 
 # Delete all.pyc files
-find /opt/datadog-agent -name '*.py[co]' -delete
+find /opt/datadog-agent -name '*.py[co]' -type f -delete || echo 'Unable to delete .pyc files'
 
 exit 0
 


### PR DESCRIPTION
Bad regression: this new `find` command fails if there is no
`/opt/datadog-agent`, which is the case for a fresh install.