### PR TITLE
moving CF script to omnibus repo so it is available at package upload…

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,11 +18,17 @@ RUN wget http://downloads.sourceforge.net/project/s3tools/s3cmd/1.5.2/s3cmd-1.5.
 	ln -s `pwd`/s3cmd-1.5.2/s3cmd /usr/bin/s3cmd
 
 USER jenkins
+# Let's fetch and install the cache invalidation script
+RUN wget https://github.com/DataDog/dd-agent-omnibus/archive/master.tar.gz && \
+    tar -xzvf master.tar.gz && \
+    mv dd-agent-omnibus/deploy-scripts $HOME/ && \
+    rm -rf master.tar.gz dd-agent-omnibus
+
 RUN echo 'source $HOME/.rvm/scripts/rvm' >> $HOME/.bashrc
 RUN /bin/bash -l -c "rvm install 2.2.2"
 RUN /bin/bash -l -c "rvm use 2.2.2 && \
     rvm gemset create circleci && \
-    rvm gemset use circleci && \ 
+    rvm gemset use circleci && \
     gem install deb-s3 && \
     gem install httparty"
 USER root

--- a/deploy-scripts/invalidate-apt/Gemfile
+++ b/deploy-scripts/invalidate-apt/Gemfile
@@ -1,0 +1,5 @@
+source 'https://rubygems.org'
+
+gem 'cloudfront-invalidator', '~> 0.2.1'
+gem 'aws-sdk', '~> 2'
+gem 'trollop'

--- a/deploy-scripts/invalidate-apt/Gemfile.lock
+++ b/deploy-scripts/invalidate-apt/Gemfile.lock
@@ -1,0 +1,27 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    aws-sdk (2.1.8)
+      aws-sdk-resources (= 2.1.8)
+    aws-sdk-core (2.1.8)
+      jmespath (~> 1.0)
+    aws-sdk-resources (2.1.8)
+      aws-sdk-core (= 2.1.8)
+    cloudfront-invalidator (0.2.1)
+      ruby-hmac
+    jmespath (1.0.2)
+      multi_json (~> 1.0)
+    multi_json (1.11.2)
+    ruby-hmac (0.4.0)
+    trollop (2.1.2)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  aws-sdk (~> 2)
+  cloudfront-invalidator (~> 0.2.1)
+  trollop
+
+BUNDLED WITH
+   1.10.5

--- a/deploy-scripts/invalidate-apt/README.md
+++ b/deploy-scripts/invalidate-apt/README.md
@@ -1,0 +1,27 @@
+# Invalidate Objects from CloudFront
+
+This tool lists all objects in an S3 bucket and identifies any objects that dont have version
+numbers in their file name.  It then invalidates those objects from the specified cloudfront cache.
+
+## Requirements
+
+* Ruby 2.x
+* AWS IAM Keys with access to s3:listbucket for the buckets of interest and CreateInvalidation for
+the cloudfront buckets of interest.
+
+## Install
+
+* bundle install
+
+## Usage
+
+invalidate.rb accepts the following options:
+Options:
+  -a, --aws-key=<s>         AWS Public Key
+  -w, --aws-secret=<s>      AWS Secret Key
+  -b, --bucket=<s>          S3 Bucket to check for objects
+  -d, --distribution=<s>    Cloudfront distribution to invalidate from
+  -h, --help                Show this message
+
+It will also respect AWS_SECRET_ACCESS_KEY and AWS_ACCESS_KEY_ID environment variables, if they
+are set.

--- a/deploy-scripts/invalidate-apt/invalidate.rb
+++ b/deploy-scripts/invalidate-apt/invalidate.rb
@@ -1,0 +1,30 @@
+#!/usr/bin/env ruby
+
+require 'cloudfront-invalidator'
+require 'aws-sdk'
+require 'trollop'
+
+opts = Trollop::options do
+  opt :aws_key, "AWS Public Key",  :type => :string, :default => ENV['AWS_ACCESS_KEY_ID']
+  opt :aws_secret, "AWS Secret Key",  :type => :string, :default => ENV['AWS_SECRET_ACCESS_KEY']
+  opt :bucket, "S3 Bucket to check for objects",  :type => :string, :default => nil
+  opt :distribution, "Cloudfront distribution to invalidate from",  :type => :string, :default => nil
+end
+
+Trollop::die :aws_key, "You must specify AWS credentials" if opts[:aws_key].nil?
+Trollop::die :aws_secret, "You must specify AWS credentials" if opts[:aws_secret].nil?
+Trollop::die :bucket, "You must specify a bucket" if opts[:bucket].nil?
+Trollop::die :distribution, "You must specify a cloudfront distribution" if opts[:distribution].nil?
+
+Aws.config.update(region: 'us-east-1',
+                  credentials: Aws::Credentials.new(opts[:aws_key], opts[:aws_secret]))
+
+s3 = Aws::S3::Resource.new
+
+objects = []
+s3.bucket(opts[:bucket]).objects.each do |obj|
+  objects.push('/' + obj.key) if obj.key.split('/').last !~ /[0-9]/
+end
+
+invalidator = CloudfrontInvalidator.new(opts[:aws_key], opts[:aws_secret], opts[:distribution])
+invalidator.invalidate(objects)


### PR DESCRIPTION
This adds a short script that can be used to invalidate CloudFront caches that sit in front of our repos when we publish new packages. 