### PR TITLE
[postinst] Set dd-agent as owner of the run/ directory

### DIFF
--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -67,6 +67,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
   chown -R dd-agent:root ${LOG_DIR}
   chown root:root /etc/init.d/datadog-agent
   chown -R root:root /opt/datadog-agent
+  chown -R dd-agent:root ${RUN_DIR}
 
   if command -v chkconfig >/dev/null 2>&1; then
       chkconfig --add datadog-agent


### PR DESCRIPTION
Was previously set correctly (see https://github.com/DataDog/dd-agent-omnibus/blob/5.4.x/package-scripts/datadog-agent/postinst#L55) but got removed by mistake, which made dd-agent unable to write pid and jmx status files in the run/ directory.