### PR TITLE
Fix dd-agent CLI on Linux

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -97,15 +97,9 @@ if linux?
   # Custom checks directory
   extra_package_file "/etc/dd-agent/checks.d"
 
-  # Symbolic links to the agent "binaries"
-  extra_package_file '/usr/bin/dd-agent'
-  extra_package_file '/usr/bin/dogstatsd'
-  extra_package_file '/usr/bin/dd-forwarder'
-
   # Linux-specific dependencies
   dependency 'procps-ng'
   dependency 'sysstat'
-
 end
 
 # Mac and Windows

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -51,14 +51,6 @@ build do
       copy 'conf.d', '/etc/dd-agent/'
       mkdir '/etc/dd-agent/checks.d/'
       command 'chmod 755 /etc/init.d/datadog-agent'
-
-      # Create symlinks
-      command 'ln -sf /opt/datadog-agent/agent/agent.py /usr/bin/dd-agent'
-      command 'ln -sf /opt/datadog-agent/agent/dogstatsd.py /usr/bin/dogstatsd'
-      command 'ln -sf /opt/datadog-agent/agent/ddagent.py /usr/bin/dd-forwarder'
-      command 'chmod 755 /usr/bin/dd-agent'
-      command 'chmod 755 /usr/bin/dogstatsd'
-      command 'chmod 755 /usr/bin/dd-forwarder'
   end
 
   if osx?

--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -73,6 +73,11 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
       chkconfig --add datadog-agent
   fi
 
+  # Create symlinks to the various agent's components
+  ln -sf $INSTALL_DIR/agent/agent.py /usr/bin/dd-agent
+  chown -R dd-agent:root /usr/bin/dd-agent
+  chmod 755 /usr/bin/dd-agent
+
   # The configcheck call will return zero if the config is valid, which means we
   # can restart the agent without taking the risk to trigger an error in the
   # postinst script . If the config file doesn't exist (RETVAL=3), the user is

--- a/package-scripts/datadog-agent/postrm
+++ b/package-scripts/datadog-agent/postrm
@@ -10,6 +10,7 @@ if [ -f "/etc/debian_version" ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$
         rm -rf /var/log/datadog
         rm -rf /etc/dd-agent
         rm -rf /var/log/datadog
+        rm -f /usr/bin/dd-agent
     fi
 elif [ -f "/etc/redhat-release" ] || [ "$LINUX_DISTRIBUTION" == "RedHat" ] || [ "$LINUX_DISTRIBUTION" == "CentOS" ] || [ "$LINUX_DISTRIBUTION" == "openSUSE" ] || [ "$LINUX_DISTRIBUTION" == "Amazon" ]; then
     case "$*" in


### PR DESCRIPTION
The `/usr/bin{dd-agent,dogstatsd,dd-forwarder}` commands haven't worked
anymore since... a big while. I suspect that this is due to a slight
variation in the behaviour of the `extra_package_file` between Omnibus 3
and Omnibus 4 but I didn't really have time to dig more into it.

This fix just moves the creation of these files to the `postinst` script
which fixes the issue in a rather simple way. These same files also get
deleted in the `postrm` script so that these commands simply don't exist
anymore after removing the agent.