### PR TITLE
[linux] Keep `dd-agent` CLI in packages file list

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -88,14 +88,20 @@ if linux?
   end
 
   # Supervisord config file for the agent
-  extra_package_file "/etc/dd-agent/supervisor.conf"
+  extra_package_file '/etc/dd-agent/supervisor.conf'
 
   # Example configuration files for the agent and the checks
-  extra_package_file "/etc/dd-agent/datadog.conf.example"
-  extra_package_file "/etc/dd-agent/conf.d"
+  extra_package_file '/etc/dd-agent/datadog.conf.example'
+  extra_package_file '/etc/dd-agent/conf.d'
 
   # Custom checks directory
-  extra_package_file "/etc/dd-agent/checks.d"
+  extra_package_file '/etc/dd-agent/checks.d'
+
+  # dd-agent CLI (it's just an empty file at this point but it needs to exist,
+  # otherwise, since Yum installs the new package and then removes files from the old
+  # package, this has to be there to ensure `/usr/bin/dd-agent` is actually in the
+  # RPM package file list)
+  extra_package_file '/usr/bin/dd-agent'
 
   # Linux-specific dependencies
   dependency 'procps-ng'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -51,6 +51,7 @@ build do
       copy 'conf.d', '/etc/dd-agent/'
       mkdir '/etc/dd-agent/checks.d/'
       command 'chmod 755 /etc/init.d/datadog-agent'
+      touch '/usr/bin/dd-agent'
   end
 
   if osx?

--- a/package-scripts/datadog-agent/postrm
+++ b/package-scripts/datadog-agent/postrm
@@ -10,7 +10,6 @@ if [ -f "/etc/debian_version" ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$
         rm -rf /var/log/datadog
         rm -rf /etc/dd-agent
         rm -rf /var/log/datadog
-        rm -f /usr/bin/dd-agent
     fi
 elif [ -f "/etc/redhat-release" ] || [ "$LINUX_DISTRIBUTION" == "RedHat" ] || [ "$LINUX_DISTRIBUTION" == "CentOS" ] || [ "$LINUX_DISTRIBUTION" == "openSUSE" ] || [ "$LINUX_DISTRIBUTION" == "Amazon" ]; then
     case "$*" in


### PR DESCRIPTION
Otherwise the `/usr/bin/dd-agent` binary gets removed by the post
removal cript of the old package which is run after the post install
script of the new package... yes :/