### PR TITLE
[linux] Fixed dd-agent CLI: Part II

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -88,14 +88,19 @@ if linux?
   end
 
   # Supervisord config file for the agent
-  extra_package_file "/etc/dd-agent/supervisor.conf"
+  extra_package_file '/etc/dd-agent/supervisor.conf'
 
   # Example configuration files for the agent and the checks
-  extra_package_file "/etc/dd-agent/datadog.conf.example"
-  extra_package_file "/etc/dd-agent/conf.d"
+  extra_package_file '/etc/dd-agent/datadog.conf.example'
+  extra_package_file '/etc/dd-agent/conf.d'
 
   # Custom checks directory
-  extra_package_file "/etc/dd-agent/checks.d"
+  extra_package_file '/etc/dd-agent/checks.d'
+
+  # Just a dummy file that needs to be in the RPM package list if we don't want it to be removed
+  # during RPM upgrades. (the old files from the RPM file listthat are not in the new RPM file
+  # list will get removed, that's why we need this one here)
+  extra_package_file '/usr/bin/dd-agent'
 
   # Linux-specific dependencies
   dependency 'procps-ng'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -51,6 +51,7 @@ build do
       copy 'conf.d', '/etc/dd-agent/'
       mkdir '/etc/dd-agent/checks.d/'
       command 'chmod 755 /etc/init.d/datadog-agent'
+      touch '/usr/bin/dd-agent'
   end
 
   if osx?

--- a/package-scripts/datadog-agent/README.md
+++ b/package-scripts/datadog-agent/README.md
@@ -1,0 +1,25 @@
+The order in which these script are executed varies between APT and YUM which can lead to some
+rather sneaky bugs. Here's the standard order for updates:
+
+APT (source https://debian-handbook.info/browse/stable/sect.package-meta-information.html):
+-------------------------------------------------------------------------------------------
+* `prerm` script of the old package (with arguments: `upgrade <new-version>`)
+* `preinst` script of the new package (with arguments: `upgrade <old-version>`)
+* New files get unpacked based on the file list embedded in the `.deb` package
+* `postrm` script from the old package (with arguments `upgrade <new-version>`)
+* `dpkg` updates the files list, removes the files that don't exist anymore, etc.
+* `postinst` of the new script is run (with arguments `configure <lst-configured-version>`
+
+YUM (source: various Stackoverflow posts + local experiments):
+--------------------------------------------------------------
+
+* `pretrans` of new package
+* `preinst` of new package`
+* Files in the list get copied
+* `prerm` of old package
+* Files in the old package file list that are not in the new one's get removed
+* `postrm` of the old package gets run
+* `posttrans` of the old package is ran
+
+One thing to notice is that if you remove files or other components in the `postrm` script,
+updates won't work as expected with YUM.

--- a/package-scripts/datadog-agent/postrm
+++ b/package-scripts/datadog-agent/postrm
@@ -10,7 +10,6 @@ if [ -f "/etc/debian_version" ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$
         rm -rf /var/log/datadog
         rm -rf /etc/dd-agent
         rm -rf /var/log/datadog
-        rm -f /usr/bin/dd-agent
     fi
 elif [ -f "/etc/redhat-release" ] || [ "$LINUX_DISTRIBUTION" == "RedHat" ] || [ "$LINUX_DISTRIBUTION" == "CentOS" ] || [ "$LINUX_DISTRIBUTION" == "openSUSE" ] || [ "$LINUX_DISTRIBUTION" == "Amazon" ]; then
     case "$*" in


### PR DESCRIPTION
The order in with package scripts get executed during updates with YUM
led to an unexpected behaviour. After a couple of minutes of
facepalming, a decent fix has been implemented. There's also a README in
the `package-scripts/datadog-agent` folder that details a bit more how
updates are handled by APT and YUM, and there's a couple of rather
important differences to pay attention to when updating these scripts :)