### PR TITLE
[Service discovery] Add service_discovery folder to the agent.

### DIFF
--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -28,6 +28,7 @@ build do
   copy 'dogstream', "#{install_dir}/agent/"
   copy 'resources', "#{install_dir}/agent/"
   copy 'utils', "#{install_dir}/agent/"
+  copy 'service_discovery', "#{install_dir}/agent/"
   command "cp *.py #{install_dir}/agent/"
   copy 'datadog-cert.pem', "#{install_dir}/agent/"
 


### PR DESCRIPTION
related to: https://github.com/DataDog/dd-agent/pull/2008 and https://github.com/DataDog/omnibus-software/pull/25