### PR TITLE
Add datadogpy

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -153,6 +153,9 @@ dependency 'pyvmomi'
 dependency 'requests'
 dependency 'snakebite'
 
+# Additional software
+dependency 'datadogpy'
+
 # Datadog gohai is built last before dataadog agent since it should always
 # be rebuilt (if put above, it would dirty the cache of the dependencies below
 # and trigger a useless rebuild of many packages)


### PR DESCRIPTION
The `dog` and `dogwrap` scripts are shipped in `/opt/datadog-agent/bin/`.

To avoid conflicting with an existing install of datadogpy I haven't linked these scripts to `/usr/bin/` or to any other dir that is in the `PATH` by default, but we could do it if it makes sense.

Requires https://github.com/DataDog/omnibus-software/pull/32

Fixes #3