### PR TITLE
[python] Remove compiled python files from package

### DIFF
--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -53,8 +53,10 @@ build do
       command 'chmod 755 /etc/init.d/datadog-agent'
       touch '/usr/bin/dd-agent'
 
-      # Python-compile python's .py files so that the .pyc files have up-to-date timestamps with their .py counterparts
-      command "find #{install_dir}/embedded -name '*.pyc' | sed s/\\.pyc$/\\.py/ | #{install_dir}/embedded/bin/python -m compileall -q -i -"
+      # Remove the .pyc and .pyo files from the package and list them in a file
+      # so that the prerm script knows which compiled files to remove
+      command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
+      command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
   end
 
   if osx?

--- a/package-scripts/datadog-agent/prerm
+++ b/package-scripts/datadog-agent/prerm
@@ -28,8 +28,14 @@ else
     exit 1;
 fi
 
-# Delete all.pyc files
+# Delete all.pyc files in the agent's dir
 find /opt/datadog-agent/agent -name '*.py[co]' -type f -delete || echo 'Unable to delete .pyc files'
 
-exit 0
+# Delete all the .pyc files in the embedded dir that are part of the agent's package
+# (i.e. not from packages installed manually by the user)
+if [ -f "/opt/datadog-agent/embedded/.py_compiled_files.txt" ]; then
+    # (commented lines are filtered out)
+    cat /opt/datadog-agent/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+fi
 
+exit 0


### PR DESCRIPTION
We keep a list of the .pyc/.pyo files so that we can selectively
remove them in the pkg's prerm script.

Fixes #64 