### PR TITLE
Make go-metro Linux-specific

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -157,11 +157,13 @@ dependency 'snakebite'
 # Additional software
 dependency 'datadogpy'
 
-# Datadog gohai is built last before dataadog agent since it should always
-# be rebuilt (if put above, it would dirty the cache of the dependencies below
+# datadog-gohai and datadog-metro are built last before datadog-agent since they should always
+# be rebuilt (if put above, they would dirty the cache of the dependencies below
 # and trigger a useless rebuild of many packages)
 dependency 'datadog-gohai'
-dependency 'datadog-metro'
+if linux?
+  dependency 'datadog-metro'
+end
 
 # Datadog agent
 dependency 'datadog-agent'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -119,7 +119,7 @@ build do
 
     # conf
     mkdir "#{install_dir}/etc"
-    command "grep -v 'user=dd-agent' packaging/supervisor.conf > #{install_dir}/etc/supervisor.conf"
+    copy "packaging/osx/supervisor.conf", "#{install_dir}/etc/supervisor.conf"
     copy 'datadog.conf.example', "#{install_dir}/etc/datadog.conf.example"
     command "cp -R conf.d #{install_dir}/etc/"
     copy 'packaging/osx/com.datadoghq.Agent.plist.example', "#{install_dir}/etc/"


### PR DESCRIPTION
We also switch to a different supervisor.conf file because of the
related changes to supervisor.conf introduced by go-metro.

The `grep` on `supervisor.conf` is not necessary anymore (`user=dd-agent` has been removed on the related dd-agent PR).

Related to https://github.com/DataDog/dd-agent/pull/2297