### PR TITLE
[prerm][python] Better handling of the pyc/pyo files removal on RPM

### DIFF
--- a/package-scripts/datadog-agent/README.md
+++ b/package-scripts/datadog-agent/README.md
@@ -10,16 +10,16 @@ APT (source https://debian-handbook.info/browse/stable/sect.package-meta-informa
 * `dpkg` updates the files list, removes the files that don't exist anymore, etc.
 * `postinst` of the new script is run (with arguments `configure <lst-configured-version>`
 
-YUM (source: various Stackoverflow posts + local experiments):
+YUM (source: https://fedoraproject.org/wiki/Packaging:Scriptlets):
 --------------------------------------------------------------
 
 * `pretrans` of new package
-* `preinst` of new package`
+* `preinst` of new package
 * Files in the list get copied
 * `prerm` of old package
 * Files in the old package file list that are not in the new one's get removed
 * `postrm` of the old package gets run
-* `posttrans` of the old package is ran
+* `posttrans` of the _new_ package is run
 
 One thing to notice is that if you remove files or other components in the `postrm` script,
 updates won't work as expected with YUM.

--- a/package-scripts/datadog-agent/posttrans
+++ b/package-scripts/datadog-agent/posttrans
@@ -1,3 +1,9 @@
+#! /bin/sh
+
+# This script is RPM-specific
+# It is run at the very end of an install/upgrade of the package
+# It is NOT run on removal of the package
+
 getent group dd-agent >/dev/null || groupadd -r dd-agent
 getent passwd dd-agent >/dev/null || \
     useradd -r -M -g dd-agent -d /usr/share/datadog/agent -s /bin/sh \

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -43,6 +43,12 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     if [ -f "/etc/init.d/datadog-agent" ]; then
       /etc/init.d/datadog-agent stop || true
     fi
+
+    # Delete all the .pyc/.pyo files in the embedded dir that are part of the old agent's package
+    if [ -f "/opt/datadog-agent/embedded/.py_compiled_files.txt" ]; then
+        # (commented lines are filtered out)
+        cat /opt/datadog-agent/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+    fi
   else
     echo "[ ${Red}FAILED ${RCol}]\tYour system is currently not supported by this script.";
     exit 1;

--- a/package-scripts/datadog-agent/prerm
+++ b/package-scripts/datadog-agent/prerm
@@ -1,6 +1,16 @@
 #! /bin/sh
 LINUX_DISTRIBUTION=$(grep -Eo "(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon)" /etc/issue)
 
+remove_py_compiled_files()
+{
+    # Delete all the .pyc files in the embedded dir that are part of the agent's package
+    if [ -f "/opt/datadog-agent/embedded/.py_compiled_files.txt" ]; then
+        # (commented lines are filtered out)
+        cat /opt/datadog-agent/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
+    fi
+}
+
+
 if [ -f "/etc/debian_version" ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$LINUX_DISTRIBUTION" == "Ubuntu" ]; then
     if command -v invoke-rc.d >/dev/null 2>&1; then
         invoke-rc.d datadog-agent stop || true
@@ -11,14 +21,19 @@ if [ -f "/etc/debian_version" ] || [ "$LINUX_DISTRIBUTION" == "Debian" ] || [ "$
     else
         /etc/init.d/datadog-agent stop || true
     fi
+
+    remove_py_compiled_files
 elif [ -f "/etc/redhat-release" ] || [ "$LINUX_DISTRIBUTION" == "RedHat" ] || [ "$LINUX_DISTRIBUTION" == "CentOS" ] || [ "$LINUX_DISTRIBUTION" == "openSUSE" ] || [ "$LINUX_DISTRIBUTION" == "Amazon" ]; then
     case "$*" in
           0)
             # We're uninstalling.
             /etc/init.d/datadog-agent stop
+
+            remove_py_compiled_files
             ;;
           1)
             # We're upgrading. Do nothing.
+            # The preinst script has taken care of removing the .pyc/.pyo files
             ;;
           *)
             ;;
@@ -30,12 +45,5 @@ fi
 
 # Delete all.pyc files in the agent's dir
 find /opt/datadog-agent/agent -name '*.py[co]' -type f -delete || echo 'Unable to delete .pyc files'
-
-# Delete all the .pyc files in the embedded dir that are part of the agent's package
-# (i.e. not from packages installed manually by the user)
-if [ -f "/opt/datadog-agent/embedded/.py_compiled_files.txt" ]; then
-    # (commented lines are filtered out)
-    cat /opt/datadog-agent/embedded/.py_compiled_files.txt | grep -v '^#' | xargs rm -f
-fi
 
 exit 0


### PR DESCRIPTION
With RPM, if we remove the pyc/pyo files in the `prerm` script, when
the package is upgraded, we end up removing the files that are listed
in the `.py_compiled_files.txt` file of the _new_ version of the
package because the files of the new package get copied _before_ the
`prerm` script of the old package is run.

To avoid this, on RPM, we clean the pyc/pyo files in the prerm script
only when the package is removed. When the package is upgraded we do
the cleaning in the preinst script.

Behaviour unchanged for DEBs.

Also, updated docs.