### PR TITLE
[ruby] Pin ohai version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,3 +2,4 @@ source 'https://rubygems.org'
 gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: 'datadog-5.0.0'
 gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', branch: ENV['OMNIBUS_SOFTWARE_BRANCH']
 gem 'httparty'
+gem 'ohai', '~> 8.10.0'


### PR DESCRIPTION
Pin to 8.10.0 because the next version (8.11.1) doesn't require
the correct versions of its dependencies and calls undefined
methods.

Can be reverted as soon as ohai fixes its dependencies.