### PR TITLE
[Integrations] Add commands to package an integration (rebased)

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
 source 'https://rubygems.org'
-gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: 'datadog-5.0.0'
+gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: ENV['OMNIBUS_RUBY_BRANCH']
 gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', branch: ENV['OMNIBUS_SOFTWARE_BRANCH']
 gem 'httparty'

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,0 +1,69 @@
+PROJECT_DIR='/dd-agent-omnibus'
+
+namespace :agent do
+  desc 'Cleanup generated files'
+  task :clean do
+    puts "Clean up generated files"
+    sh "rm -rf /var/cache/omnibus/pkg/*"
+    sh "rm -f /etc/init.d/datadog-agent"
+    sh "rm -rf /etc/dd-agent"
+    sh "rm -rf /opt/datadog-agent"
+  end
+
+  desc 'Pull the integrations repo'
+  task :'pull-integrations' do
+    sh "cd /#{ENV['INTEGRATIONS_REPO']} &&
+        git fetch --all &&
+        git checkout dd-check-#{ENV['INTEGRATION']}-#{ENV['VERSION']} &&
+        git reset --hard"
+  end
+
+  desc 'Execute script'
+  task :'execute-script' do
+    sh "cd #{PROJECT_DIR} && bundle update"
+    puts "building integration #{ENV['INTEGRATION']}"
+
+    header = erb_header({
+      'name' => "#{ENV['INTEGRATION']}",
+      'version' => "#{ENV['VERSION']}",
+      'build_iteration' => "#{ENV['BUILD_ITERATION']}"
+    })
+    sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/project.rb.erb) | erb > #{PROJECT_DIR}/config/projects/dd-check-#{ENV['INTEGRATION']}.rb"
+
+    header = erb_header({
+      'name' => "#{ENV['INTEGRATION']}",
+      'PROJECT_DIR' => "#{PROJECT_DIR}",
+      'integrations_repo' => "#{ENV['INTEGRATIONS_REPO']}"
+    })
+    sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/software.rb.erb) | erb > #{PROJECT_DIR}/config/software/dd-check-#{ENV['INTEGRATION']}-software.rb"
+
+    sh "cd #{PROJECT_DIR} && bin/omnibus build dd-check-#{ENV['INTEGRATION']} --output_manifest=false"
+  end
+
+  desc 'Build an integration'
+  task :'build-integration' do
+    Rake::Task["agent:clean"].invoke
+    Rake::Task["env:import-rpm-key"].invoke
+    Rake::Task["agent:pull-integrations"].invoke
+    Rake::Task["agent:execute-script"].invoke
+  end
+
+end
+
+namespace :env do
+  desc 'Import signing RPM key'
+  task :'import-rpm-key' do
+    # If an RPM_SIGNING_PASSPHRASE has been passed, let's import the signing key
+    sh "if [ \"$RPM_SIGNING_PASSPHRASE\" ]; then gpg --import /keys/RPM-SIGNING-KEY.private; fi"
+  end
+end
+
+def erb_header(variables)
+  # ERB does not support setting template variables on the command line
+  # this method generates a header usable by a ERB file
+  out = ""
+  variables.each do |key, value|
+    out += "<% #{key}=\"#{value}\" %>"
+  end
+  out
+end

--- a/build_integration.sh
+++ b/build_integration.sh
@@ -1,0 +1,16 @@
+#!/bin/bash -e
+
+###########################
+#
+# WARNING: You need to rebuild the docker images if you do any changes to this file
+#
+############################
+
+PROJECT_DIR='/dd-agent-omnibus'
+
+cd $PROJECT_DIR
+git fetch --all
+git checkout $OMNIBUS_BRANCH
+git reset --hard origin/$OMNIBUS_BRANCH
+
+rake agent:build-integration

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -11,6 +11,7 @@ PROJECT_NAME=datadog-agent
 LOG_LEVEL=${LOG_LEVEL:-"info"}
 OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
 OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
+OMNIBUS_RUBY_BRANCH=${OMNIBUS_RUBY_BRANCH:-"datadog-5.0.0"}
 
 # Clean up omnibus artifacts
 rm -rf /var/cache/omnibus/pkg/*

--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -1,0 +1,50 @@
+name 'dd-check-<%= name %>'
+maintainer 'Datadog Packages <package@datadoghq.com>'
+homepage 'http://www.datadoghq.com'
+install_dir '/opt/datadog-agent'
+
+build_version '<%= version %>'
+build_iteration <%= build_iteration %>
+json_manifest_path "#{install_dir}/3rd-party/<%= name %>/version-manifest.json"
+
+description '<%= name %> Integration for Datadog Monitoring Agent
+ The Datadog Monitoring Agent is a lightweight process that monitors system
+ processes and services, and sends information back to your Datadog account.
+ .
+ This package relies on the Datadog agent to be installed, and installs the required files
+ for the <%= name %> integration to be configured.
+ .
+ See http://www.datadoghq.com/ for more information
+'
+
+# ------------------------------------
+# Generic package information
+# ------------------------------------
+
+# .deb specific flags
+package :deb do
+  vendor 'Datadog <info@datadoghq.com>'
+  license 'Simplified BSD License'
+  section 'utils'
+  priority 'extra'
+end
+
+# .rpm specific flags
+package :rpm do
+  vendor 'Datadog <package@datadoghq.com>'
+  license 'Simplified BSD License'
+  category 'System Environment/Daemons'
+  priority 'extra'
+  if ENV.has_key?('RPM_SIGNING_PASSPHRASE') and not ENV['RPM_SIGNING_PASSPHRASE'].empty?
+    signing_passphrase "#{ENV['RPM_SIGNING_PASSPHRASE']}"
+  end
+end
+
+dependency 'preparation'  # creates required build directories
+dependency 'dd-check-<%= name %>-software'
+
+extends_packages('datadog-agent', 'datadog')
+
+extra_package_file '/etc/dd-agent/conf.d/<%= name %>.yaml.example'
+
+exclude '\.git*'

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -1,0 +1,24 @@
+name "dd-check-<%= name %>-software"
+default_version "0.0.1"
+
+require 'json'
+require_relative "<%= PROJECT_DIR %>/resources/datadog-integrations/validate_manifest"
+integration_source_folder = '/<%= integrations_repo %>/<%= name %>'
+integration_agent_folder = "#{install_dir}/3rd-party/<%= name %>"
+
+build do
+  # validate manifest.json
+  manifest = JSON.parse(File.read("#{integration_source_folder}/manifest.json"))
+  validate_manifest(manifest)
+
+  # copy files
+  mkdir "#{integration_agent_folder}"
+  copy "#{integration_source_folder}/conf.yaml.example", "/etc/dd-agent/conf.d/<%= name %>.yaml.example"
+  command "echo \"#{integration_agent_folder}/lib\" > #{install_dir}/embedded/lib/python2.7/site-packages/#{name}.pth"
+  for file in ["check.py", "manifest.json", "requirements.txt", "README.md"]
+    copy "#{integration_source_folder}/#{file}", "#{integration_agent_folder}/#{file}"
+  end
+
+  # install requirements
+  command "#{install_dir}/embedded/bin/pip install -I --target=#{integration_agent_folder}/lib -r #{integration_source_folder}/requirements.txt"
+end

--- a/resources/datadog-integrations/validate_manifest.rb
+++ b/resources/datadog-integrations/validate_manifest.rb
@@ -1,0 +1,23 @@
+def validate_manifest(manifest_hash)
+  puts manifest_hash
+  raise "manifest.json needs a manifest_version field" unless manifest_hash.key?("manifest_version")
+  validate_manifest_version = manifest_hash["manifest_version"].gsub! '.', '_'
+  send("validate_manifest_#{validate_manifest_version}", manifest_hash)
+  puts "manifest is valid"
+end
+
+def validate_manifest_0_1_0(manifest_hash)
+  mandatory_fields = [
+    "maintainer",
+    "manifest_version",
+    "max_agent_version",
+    "min_agent_version",
+    "name",
+    "short_description",
+    "support",
+    "version",
+  ]
+  mandatory_fields.each do |field|
+    raise "manifest.json needs proper fields, currently missing #{field}. Please refer to documentation" unless manifest_hash.key?(field)
+  end
+end


### PR DESCRIPTION
Rebased version of #68:

```
Add a build_integration.sh entry point,
Add logic to package an integration, including some content validation.
```

I just added a default `OMNIBUS_RUBY_BRANCH` in the agent build script.