### PR TITLE
Correctly set default branches for repos

### DIFF
--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -9,9 +9,9 @@
 PROJECT_DIR=dd-agent-omnibus
 PROJECT_NAME=datadog-agent
 LOG_LEVEL=${LOG_LEVEL:-"info"}
-OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
-OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
-OMNIBUS_RUBY_BRANCH=${OMNIBUS_RUBY_BRANCH:-"datadog-5.0.0"}
+export OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
+export OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
+export OMNIBUS_RUBY_BRANCH=${OMNIBUS_RUBY_BRANCH:-"datadog-5.0.0"}
 
 # Clean up omnibus artifacts
 rm -rf /var/cache/omnibus/pkg/*


### PR DESCRIPTION
We need the default branches to be specified in the _environment_
and not only as bash variables, otherwise the defaults don't actually
work

cc @truthbk 