### PR TITLE
[rpm] Add runtime dependency on `initscripts` pkg

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -47,6 +47,10 @@ package :rpm do
   end
 end
 
+if redhat?
+  runtime_dependency 'initscripts'
+end
+
 # OSX .pkg specific flags
 package :pkg do
   identifier 'com.datadoghq.agent'


### PR DESCRIPTION
On RHEL, the `initscripts` pkg contains the system scripts (`/etc/rc.d/init.d/functions`) that the init script of the agent uses (see https://github.com/DataDog/dd-agent/blob/5.8.3/packaging/centos/datadog-agent.init#L43). It's present by default on CentOS 5/6 but not on CentOS 7 so it's worth adding.

This will add `initscripts` to the `Requires:` field of the rpm pkg's spec file (see https://github.com/DataDog/omnibus-ruby/blob/67368bbf966ca9f2e425eda193f81550e2c08cdf/resources/rpm/spec.erb#L33-L35)