### PR TITLE
[f5check] Added easysnmp dependency to datadog-agent.rb

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -142,6 +142,7 @@ dependency 'zlib'
 # Check dependencies
 dependency 'adodbapi'
 dependency 'dnspython'
+dependency 'easysnmp'
 dependency 'httplib2'
 dependency 'kafka-python'
 dependency 'kazoo'


### PR DESCRIPTION
Added dependency for dd-agent f5-check pull request. Could not successfully test this change with the script provided.
https://github.com/DataDog/dd-agent/issues/2742
https://github.com/DataDog/dd-agent/pull/2743
