### PR TITLE
Fail on error in `omnibus_build.sh`

### DIFF
--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -13,6 +13,8 @@ export OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
 export OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
 export OMNIBUS_RUBY_BRANCH=${OMNIBUS_RUBY_BRANCH:-"datadog-5.0.0"}
 
+set -e
+
 # Clean up omnibus artifacts
 rm -rf /var/cache/omnibus/pkg/*
 
@@ -32,12 +34,17 @@ if [ -n "$RPM_SIGNING_PASSPHRASE" ]; then
   gpg --import /keys/RPM-SIGNING-KEY.private
 fi
 
+# the cache directories might not exist, but don't fail on that
+set +e
+
 # Last but not least, let's make sure that we rebuild the agent everytime because
 # the extra package files are destroyed when the build container stops (we have
 # to tweak omnibus-git-cache directly for that). Same for gohai and go-metro.
 git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-agent`
 git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-gohai`
 git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-metro`
+
+set -e
 
 # Install the gems we need, with stubs in bin/
 bundle update # Make sure to update to the latest version of omnibus-software


### PR DESCRIPTION
So that the whole build fails when one of the commands fails, for instance when we try checkouting  a branch/tag that doesn't exists