### PR TITLE
[service discovery][grpc] generate client code module on the fly

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -125,6 +125,7 @@ dependency 'preparation'
 
 # Agent dependencies
 dependency 'boto'
+dependency 'grpcio'
 dependency 'docker-py'
 dependency 'ntplib'
 dependency 'pycrypto'

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -164,6 +164,8 @@ dependency 'scandir'
 dependency 'snakebite'
 
 # Additional software
+dependency 'cython'
+dependency 'grpcio-tools'
 dependency 'datadogpy'
 
 # datadog-gohai and datadog-metro are built last before datadog-agent since they should always

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -31,6 +31,11 @@ build do
   command "cp *.py #{install_dir}/agent/"
   copy 'datadog-cert.pem', "#{install_dir}/agent/"
 
+  # build the rpc client
+  command_build_grpc = 'python -m grpc.tools.protoc -I./rpc/proto --python_out=./rpc/ --grpc_python_out=./rpc/'
+  command "#{command_build_grpc} ./rpc/proto/service_discovery.proto"
+  copy 'rpc', "#{install_dir}/agent/"
+
   mkdir "#{install_dir}/run/"
 
 

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -32,7 +32,7 @@ build do
   copy 'datadog-cert.pem', "#{install_dir}/agent/"
 
   # build the rpc client
-  command_build_grpc = 'python -m grpc.tools.protoc -I./rpc/proto --python_out=./rpc/ --grpc_python_out=./rpc/'
+  command_build_grpc = "#{install_dir}/embedded/bin/python -m grpc.tools.protoc -I./rpc/proto --python_out=./rpc/ --grpc_python_out=./rpc/"
   command "#{command_build_grpc} ./rpc/proto/service_discovery.proto"
   copy 'rpc', "#{install_dir}/agent/"
 

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -35,6 +35,7 @@ build do
   command_build_grpc = "#{install_dir}/embedded/bin/python -m grpc.tools.protoc -I./rpc/proto --python_out=./rpc/ --grpc_python_out=./rpc/"
   command "#{command_build_grpc} ./rpc/proto/service_discovery.proto"
   copy 'rpc', "#{install_dir}/agent/"
+  command "touch #{install_dir}/agent/rpc/__init__.py"
 
   mkdir "#{install_dir}/run/"
 


### PR DESCRIPTION
This PR will generate the code for the GRPC client module on the fly and drop it in the relevant location in the embedded agent. We might need to set the `proto` file in a single source of truth location, because if I remember correctly, we still have it in two different places (JMXfetch and dd-agent repos). Should be an easy fix.
