### PR TITLE
[jmxfetch] build jmxfetch via omnibus

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -31,10 +31,9 @@ end
 dependency 'boto'
 dependency 'docker-py'
 
-if ENV['JMX_VERSION'] && !ENV['JMX_VERSION'].empty?
-  dependency 'jmxfetch'
-  dependency 'jmxterm'
-end
+dependency 'jmxfetch'
+dependency 'jmxterm'
+
 dependency 'ntplib'
 dependency 'protobuf-py'
 dependency 'psutil'

--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -30,6 +30,11 @@ end
 # Agent dependencies
 dependency 'boto'
 dependency 'docker-py'
+
+if ENV['JMX_VERSION'] && !ENV['JMX_VERSION'].empty?
+  dependency 'jmxfetch'
+  dependency 'jmxterm'
+end
 dependency 'ntplib'
 dependency 'protobuf-py'
 dependency 'psutil'

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -9,7 +9,6 @@
 PROJECT_DIR=dd-agent-omnibus
 PROJECT_NAME=datadog-agent
 LOG_LEVEL=${LOG_LEVEL:-"info"}
-JMX_VERSION=${JMX_BRANCH:-"current"}
 export AGENT_BRANCH=${AGENT_BRANCH:-"master"}
 export OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
 export OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
@@ -18,12 +17,6 @@ export INTEGRATION_CORE_BRANCH=${INTEGRATION_CORE_BRANCH:-"master"}
 
 REMOTE_AGENT_REPO_RAW="https://raw.githubusercontent.com/DataDog/dd-agent"
 LOCAL_DD_AGENT="/dd-agent-repo"
-
-unset_jmx() {
-    echo "JMX provided by dd-agent in selected branch, JMX environment variables will be ignored."
-    unset JMX_VERSION
-    unset JMX_BRANCH
-}
 
 set -e
 
@@ -48,37 +41,16 @@ if [ -n "$RPM_SIGNING_PASSPHRASE" ]; then
   gpg --import /keys/RPM-SIGNING-KEY.private
 fi
 
+# NOTE: JMX_VERSION plays no role <5.14.x (jmx bundled with agent)
 # If "current" JMX version, set it from the corresponding agent branch config.py
-if [ "$JMX_VERSION" == "current" ]; then
-  if [ -n "$LOCAL_AGENT_REPO" ]; then
-    cd $LOCAL_DD_AGENT
-    JMX_VERSION=$(git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
-    cd -
-  else
-    JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
-  fi
-
-  if [ -n "$JMX_VERSION" ]; then
-    export JMX_VERSION=$JMX_VERSION
-  else
-    unset_jmx
-  fi
+if [ -n "$LOCAL_AGENT_REPO" ]; then
+  cd $LOCAL_DD_AGENT
+  JMX_VERSION=$(git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
+  cd -
 else
-  # just verify the specified repo supports distributing JMXFetch from standalone S3.
-  if [ -n "$LOCAL_AGENT_REPO" ]; then
-    cd $LOCAL_DD_AGENT
-    git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION'
-    if [ $? -ne 0 ]; then
-      unset_jmx
-    fi
-    cd -
-  else
-    curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION'
-    if [ $? -ne 0 ]; then
-      unset_jmx
-    fi
-  fi
+  JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
+export JMX_VERSION=$JMX_VERSION
 
 # Install the gems we need, with stubs in bin/
 bundle update # Make sure to update to the latest version of omnibus-software

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -9,10 +9,21 @@
 PROJECT_DIR=dd-agent-omnibus
 PROJECT_NAME=datadog-agent
 LOG_LEVEL=${LOG_LEVEL:-"info"}
+JMX_VERSION=${JMX_BRANCH:-"current"}
+export AGENT_BRANCH=${AGENT_BRANCH:-"master"}
 export OMNIBUS_BRANCH=${OMNIBUS_BRANCH:-"master"}
 export OMNIBUS_SOFTWARE_BRANCH=${OMNIBUS_SOFTWARE_BRANCH:-"master"}
 export OMNIBUS_RUBY_BRANCH=${OMNIBUS_RUBY_BRANCH:-"datadog-5.5.0"}
 export INTEGRATION_CORE_BRANCH=${INTEGRATION_CORE_BRANCH:-"master"}
+
+REMOTE_AGENT_REPO_RAW="https://raw.githubusercontent.com/DataDog/dd-agent"
+LOCAL_DD_AGENT="/dd-agent-repo"
+
+unset_jmx() {
+    echo "JMX provided by dd-agent in selected branch, JMX environment variables will be ignored."
+    unset JMX_VERSION
+    unset JMX_BRANCH
+}
 
 set -e
 
@@ -31,9 +42,41 @@ git fetch --all
 git checkout $OMNIBUS_BRANCH
 git reset --hard origin/$OMNIBUS_BRANCH
 
+
 # If an RPM_SIGNING_PASSPHRASE has been passed, let's import the signing key
 if [ -n "$RPM_SIGNING_PASSPHRASE" ]; then
   gpg --import /keys/RPM-SIGNING-KEY.private
+fi
+
+# If "current" JMX version, set it from the corresponding agent branch config.py
+if [ "$JMX_VERSION" == "current" ]; then
+  if [ -n "$LOCAL_AGENT_REPO" ]; then
+    cd $LOCAL_DD_AGENT
+    JMX_VERSION=$(git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
+    cd -
+  else
+    JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
+  fi
+
+  if [ -n "$JMX_VERSION" ]; then
+    export JMX_VERSION=$JMX_VERSION
+  else
+    unset_jmx
+  fi
+else
+  if [ -n "$LOCAL_AGENT_REPO" ]; then
+    cd $LOCAL_DD_AGENT
+    git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION'
+    if [ $? -ne 0 ]; then
+      unset_jmx
+    fi
+    cd -
+  else
+    curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION'
+    if [ $? -ne 0 ]; then
+      unset_jmx
+    fi
+  fi
 fi
 
 # Install the gems we need, with stubs in bin/

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -50,7 +50,7 @@ if [ -n "$LOCAL_AGENT_REPO" ]; then
 else
   JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
-export JMX_VERSION=$JMX_VERSION
+export JMX_VERSION
 
 # Install the gems we need, with stubs in bin/
 bundle update # Make sure to update to the latest version of omnibus-software

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -64,6 +64,7 @@ if [ "$JMX_VERSION" == "current" ]; then
     unset_jmx
   fi
 else
+  # just verify the specified repo supports distributing JMXFetch from standalone S3.
   if [ -n "$LOCAL_AGENT_REPO" ]; then
     cd $LOCAL_DD_AGENT
     git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION'


### PR DESCRIPTION
This PR adds the corresponding dependencies to enable building jmxfetch via omnibus-software as opposed to keeping the jar file in the `dd-agent` repo. It will also allow us to define what JMXfetch branch/tag we wish to include in the build, defaulting to `master` if none is specified.

https://github.com/DataDog/omnibus-software/pull/91