### PR TITLE
[linux] Make `dd-agent` group of etc, log, and bin files

### DIFF
--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -67,8 +67,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
   fi
 
   # Set proper rights to the dd-agent user
-  chown -R dd-agent:root ${CONFIG_DIR}
-  chown -R dd-agent:root ${LOG_DIR}
+  chown -R dd-agent:dd-agent ${CONFIG_DIR}
+  chown -R dd-agent:dd-agent ${LOG_DIR}
   chown root:root /etc/init.d/datadog-agent
   chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
@@ -78,7 +78,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
   # Create symlinks to the various agent's components
   ln -sf $INSTALL_DIR/agent/agent.py /usr/bin/dd-agent
-  chown -R dd-agent:root /usr/bin/dd-agent
+  chown -R dd-agent:dd-agent /usr/bin/dd-agent
   chmod 755 /usr/bin/dd-agent
 
   # The configcheck call will return zero if the config is valid, which means we


### PR DESCRIPTION
**NB: This deserves a mention in the Agent's CHANGELOG**

Now that all our linux packages create a `dd-agent` gzroup, it makes
sense to use it on all the files already owned by the `dd-agent` user