### PR TITLE
Fixes issues with logfile and tmpfiles

### DIFF
--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -2,8 +2,9 @@
 
 INSTALL_DIR=/opt/datadog-agent
 SYSTEM_LOG_DIR=/var/log/datadog
-DD_LOG_DIR=/opt/datadog-agent/log
+DD_LOG_DIR=$INSTALL_DIR/log
 RUN_DIR=$INSTALL_DIR/run
+TMP_DIR$INSTALL_DIR/tmp
 
 DISTRIBUTION=$(grep -Eo "(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|SUSE)" /etc/issue 2>/dev/null || uname -s)
 
@@ -119,6 +120,7 @@ elif [ "$DISTRIBUTION" = "Darwin" ]; then
   APP_DIR="/Applications/Datadog Agent.app"
   CONF_DIR=$INSTALL_DIR/etc
   RUN_DIR=$INSTALL_DIR/run
+  TMP_DIR=$INSTALL_DIR/tmp
 
   # Let's log the standard outputs of this script
   LOG_FILE="$DD_LOG_DIR/postinstall.log"
@@ -157,6 +159,9 @@ elif [ "$DISTRIBUTION" = "Darwin" ]; then
   mkdir -vp "$RUN_DIR"
   chown -vR $INSTALL_USER:admin "$RUN_DIR"
   chmod -v 755 "$RUN_DIR"
+  mkdir -vp "$TMP_DIR"
+  chown -vR $INSTALL_USER:admin "$TMP_DIR"
+  chmod -v 755 "$TMP_DIR"
 
   echo "# Creating default plist"
   sed "s|USER_NAME|$INSTALL_USER|" "$CONF_DIR/com.datadoghq.Agent.plist.example" > "$CONF_DIR/com.datadoghq.Agent.plist"

--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 INSTALL_DIR=/opt/datadog-agent
-LOG_DIR=/var/log/datadog
+SYSTEM_LOG_DIR=/var/log/datadog
+DD_LOG_DIR=/opt/datadog-agent/log
 RUN_DIR=$INSTALL_DIR/run
 
 DISTRIBUTION=$(grep -Eo "(Debian|Ubuntu|RedHat|CentOS|openSUSE|Amazon|SUSE)" /etc/issue 2>/dev/null || uname -s)
@@ -12,7 +13,9 @@ error_exit()
   exit 1
 }
 
-mkdir -p ${LOG_DIR} || error_exit "Cannot create ${LOG_DIR}!"
+mkdir -p ${DD_LOG_DIR} || error_exit "Cannot create ${DD_LOG_DIR}!"
+mkdir -p /var/log || error_exit "Cannot create /var/log!"
+ln -s /opt/datadog-agent/log /var/log/datadog
 
 # If we are inside the Docker container, do nothing
 if [ -n "$DOCKER_DD_AGENT" ]; then
@@ -68,7 +71,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
   # Set proper rights to the dd-agent user
   chown -R dd-agent:dd-agent ${CONFIG_DIR}
-  chown -R dd-agent:dd-agent ${LOG_DIR}
+  chown -R dd-agent:dd-agent ${SYSTEM_LOG_DIR}
   chown root:root /etc/init.d/datadog-agent
   chown -R dd-agent:dd-agent ${INSTALL_DIR}
 
@@ -118,8 +121,8 @@ elif [ "$DISTRIBUTION" = "Darwin" ]; then
   RUN_DIR=$INSTALL_DIR/run
 
   # Let's log the standard outputs of this script
-  LOG_FILE="$LOG_DIR/postinstall.log"
-  mkdir -vp $LOG_DIR
+  LOG_FILE="$DD_LOG_DIR/postinstall.log"
+  mkdir -vp $SYSTEM_LOG_DIR
   exec > $LOG_FILE 2>&1
 
   # Let's talk to our user installing the Agent a bit
@@ -144,8 +147,8 @@ elif [ "$DISTRIBUTION" = "Darwin" ]; then
   echo "INSTALL_USER: $INSTALL_USER"
 
   echo "# Prepareing log dir"
-  chown -vR $INSTALL_USER:admin $LOG_DIR
-  chmod -v 755 $LOG_DIR
+  chown -vR $INSTALL_USER:admin $DD_LOG_DIR
+  chmod -v 755 $DD_LOG_DIR
 
   echo "# Installing the app"
   mv -v "$OPT_APP_DIR" /Applications || echo "App already installed"


### PR DESCRIPTION
This will add the logfiles under /opt/datadog-agent/log (or equivalent) and symlink the directory to the current system log directory (`ln -s /opt/datadog-agent/log /var/log/datadog`).

It will also create the tmp_dir for osx.