### PR TITLE
[omnibus_build] set -e messing up chdir.

### DIFF
--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -23,7 +23,8 @@ rm -f /etc/init.d/datadog-agent
 rm -rf /etc/dd-agent
 rm -rf /opt/$PROJECT_NAME/*
 
-cd $PROJECT_DIR
+builtin cd $PROJECT_DIR
+
 # Allow to use a different dd-agent-omnibus branch
 git fetch --all
 git checkout $OMNIBUS_BRANCH


### PR DESCRIPTION
Required this to build: https://github.com/DataDog/docker-dd-agent-build-rpm-x64/pull/13