### PR TITLE
Add support for changing per-user to per machine install

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -85,7 +85,8 @@ package :msi do
   
   # For a consistent package management, please NEVER change this code
   upgrade_code '0c50421b-aefb-4f15-a809-7af256d608a5'
-  bundle_upgrade_code 'E6179AB5-A20F-47E0-8BA2-3AA5F0F9B014'
+  #bundle_upgrade_code 'E6179AB5-A20F-47E0-8BA2-3AA5F0F9B014'
+  bundle_upgrade_code upgrade_code
   bundle_msi true
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -227,6 +227,9 @@ if linux? and ohai['kernel']['machine'] == 'x86_64'
   dependency 'datadog-metro'
 end
 
+if windows?
+  dependency 'datadog-upgrade-helper'
+end
 if linux?
   dependency 'datadog-trace-agent'
 end

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -81,7 +81,7 @@ package :msi do
   # previous upgrade code was used for older installs, and generated
   # per-user installs.  Changing upgrade code, and switching to
   # per-machine
-  # previous upgrade_code '82210ed1-bbe4-4051-aa15-002ea31dde15'
+  per_user_upgrade_code = '82210ed1-bbe4-4051-aa15-002ea31dde15'
   
   # For a consistent package management, please NEVER change this code
   upgrade_code '0c50421b-aefb-4f15-a809-7af256d608a5'
@@ -96,7 +96,8 @@ package :msi do
     'InstallDir' => install_dir,
     'InstallFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files",
     'DistFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist",
-    'BundleUpgradeCode' => bundle_upgrade_code
+    'BundleUpgradeCode' => bundle_upgrade_code,
+    'PerUserUpgradeCode' => per_user_upgrade_code
   })
 end
 # Note: this is to try to avoid issues when upgrading from an

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -85,8 +85,6 @@ package :msi do
   
   # For a consistent package management, please NEVER change this code
   upgrade_code '0c50421b-aefb-4f15-a809-7af256d608a5'
-  #bundle_upgrade_code 'E6179AB5-A20F-47E0-8BA2-3AA5F0F9B014'
-  bundle_upgrade_code upgrade_code
   bundle_msi true
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
@@ -97,7 +95,6 @@ package :msi do
     'InstallDir' => install_dir,
     'InstallFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files",
     'DistFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist",
-    'BundleUpgradeCode' => bundle_upgrade_code,
     'PerUserUpgradeCode' => per_user_upgrade_code
   })
 end

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -78,8 +78,15 @@ end
 
 # Windows .msi specific flags
 package :msi do
+  # previous upgrade code was used for older installs, and generated
+  # per-user installs.  Changing upgrade code, and switching to
+  # per-machine
+  # previous upgrade_code '82210ed1-bbe4-4051-aa15-002ea31dde15'
+  
   # For a consistent package management, please NEVER change this code
-  upgrade_code '82210ed1-bbe4-4051-aa15-002ea31dde15'
+  upgrade_code '0c50421b-aefb-4f15-a809-7af256d608a5'
+  bundle_upgrade_code 'E6179AB5-A20F-47E0-8BA2-3AA5F0F9B014'
+  bundle_msi true
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
   if ENV['SIGN_WINDOWS']
@@ -88,7 +95,8 @@ package :msi do
   parameters({
     'InstallDir' => install_dir,
     'InstallFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/packaging/datadog-agent/win32/install_files",
-    'DistFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist"
+    'DistFiles' => "#{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist",
+    'BundleUpgradeCode' => bundle_upgrade_code
   })
 end
 # Note: this is to try to avoid issues when upgrading from an

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -2,10 +2,10 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
       xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <?include "parameters.wxi" ?>
-	<Bundle Name="Datadog Agent Upgrade Installer" 
+	<Bundle Name="Datadog Agent Installer" 
             Version="$(var.VersionNumber)" 
             Manufacturer="Datadog Inc." 
-            UpgradeCode="$(var.BundleUpgradeCode)" >
+            UpgradeCode="$(var.UpgradeCode)" >
 		
         <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" >
           <bal:WixStandardBootstrapperApplication

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -14,7 +14,7 @@
 
 		<Chain>
       <ExePackage
-        SourceFile="$(var.HelperDir)\upgrade_helper.exe"
+        SourceFile="$(var.HelperDir)\upgrade-helper.exe"
         PerMachine="yes"
         Permanent="yes"
         LogPathVariable="UninstallRelatedProductsLogPath"

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
       xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+  <?include "parameters.wxi" ?>
 	<Bundle Name="Datadog Agent Installer" 
             Version="$(var.VersionNumber)" 
             Manufacturer="Datadog Inc." 

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
+      xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
+	<Bundle Name="Datadog Agent Installer" 
+            Version="$(var.VersionNumber)" 
+            Manufacturer="Datadog Inc." 
+            UpgradeCode="$(var.BundleUpgradeCode)" >
+		
+        <BootstrapperApplicationRef Id="WixStandardBootstrapperApplication.RtfLicense" >
+          <bal:WixStandardBootstrapperApplication
+          LicenseFile="Resources\assets\license.rtf" 
+          />
+        </BootstrapperApplicationRef>
+
+		<Chain>
+      <ExePackage
+        SourceFile="$(var.HelperDir)\upgrade_helper.exe"
+        PerMachine="yes"
+        Permanent="yes"
+        LogPathVariable="UninstallRelatedProductsLogPath"
+        InstallCommand="--uninstall"
+        >
+        <!-- 0 indicates it's not installed, proceed-->
+        <ExitCode Value="0" Behavior="success"/>
+        <!-- 1 indicates was installed by this user, uninstalled, proceed-->
+        <ExitCode Value="1" Behavior="success"/>
+        <!-- -1 indicates it's installed as another user, fail -->
+        <ExitCode Value="-1" Behavior="error"/> 
+        <!-- All other values error -->
+      </ExePackage>
+      <MsiPackage SourceFile="$(var.DDMSI)"/>
+		</Chain>
+	</Bundle>
+</Wix>

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -19,7 +19,7 @@
         PerMachine="yes"
         Permanent="yes"
         LogPathVariable="UninstallRelatedProductsLogPath"
-        InstallCommand="--uninstall"
+        InstallCommand="-oldcode={$(var.PerUserUpgradeCode)} -newcode={$(var.UpgradeCode)}"
         >
         <!-- 0 indicates it's not installed, proceed-->
         <ExitCode Value="0" Behavior="success"/>

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -2,7 +2,7 @@
 <Wix xmlns="http://schemas.microsoft.com/wix/2006/wi"
       xmlns:bal="http://schemas.microsoft.com/wix/BalExtension">
   <?include "parameters.wxi" ?>
-	<Bundle Name="Datadog Agent Installer" 
+	<Bundle Name="Datadog Agent Upgrade Installer" 
             Version="$(var.VersionNumber)" 
             Manufacturer="Datadog Inc." 
             UpgradeCode="$(var.BundleUpgradeCode)" >

--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -29,7 +29,7 @@
         <ExitCode Value="-1" Behavior="error"/> 
         <!-- All other values error -->
       </ExePackage>
-      <MsiPackage SourceFile="$(var.DDMSI)"/>
+      <MsiPackage SourceFile="$(var.PackageMsi)"/>
 		</Chain>
 	</Bundle>
 </Wix>

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -24,6 +24,7 @@
              Comments="Copyright 2015 Datadog, Inc."
              Description="Datadog Agent v$(var.DisplayVersionNumber)"
              Manufacturer="!(loc.ManufacturerName)"
+             InstallScope="perMachine"
              InstallerVersion="400"
              Languages="1033"
              InstallPrivileges="elevated"


### PR DESCRIPTION
Prior versions installed as perUser, which is undesirable.

Set our installation to per machine.
Provide wrapper executable which will uninstall the old (per-user) version and install the new (per-machine) version.  Note that the wrapper executable still needs to be run as the same user as the original install, or the wrapper will fail (but will fail rather than leaving with overlapping installs)