### PR TITLE
enables building of multiple integrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,3 +3,4 @@ gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: ENV['OM
 gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', branch: ENV['OMNIBUS_SOFTWARE_BRANCH']
 gem 'httparty'
 gem 'win32-process'
+gem 'ohai'

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -1,14 +1,19 @@
 require 'json'
+require 'ohai'
+
 PROJECT_DIR='/dd-agent-omnibus'
+
+@ohai = Ohai::System.new.tap { |o| o.all_plugins(%w{platform}) }.data
 
 namespace :agent do
   desc 'Cleanup generated files'
-  task :clean do
+  task :clean do |t|
     puts "Clean up generated files"
     sh "rm -rf /var/cache/omnibus/pkg/*"
     sh "rm -f /etc/init.d/datadog-agent"
     sh "rm -rf /etc/dd-agent"
     sh "rm -rf /opt/datadog-agent"
+    t.reenable
   end
 
   desc 'Pull the integrations repo'
@@ -23,41 +28,34 @@ namespace :agent do
     sh "cd /#{ENV['INTEGRATIONS_REPO']} && git reset --hard"
   end
 
-  desc 'Execute script'
-  task :'execute-script' do
-    sh "cd #{PROJECT_DIR} && bundle update"
-    puts "building integration #{ENV['INTEGRATION']}"
-
-    manifest = JSON.parse(File.read("/#{ENV['INTEGRATIONS_REPO']}/#{ENV['INTEGRATION']}/manifest.json"))
-    # The manifest should always have a version
-    integration_version = manifest['version']
-
-    header = erb_header({
-      'name' => "#{ENV['INTEGRATION']}",
-      'version' => "#{integration_version}",
-      'build_iteration' => "#{ENV['BUILD_ITERATION']}",
-      'integrations_repo' => "#{ENV['INTEGRATIONS_REPO']}"
-    })
-    sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/project.rb.erb) | erb > #{PROJECT_DIR}/config/projects/dd-check-#{ENV['INTEGRATION']}.rb"
-
-    header = erb_header({
-      'name' => "#{ENV['INTEGRATION']}",
-      'PROJECT_DIR' => "#{PROJECT_DIR}",
-      'integrations_repo' => "#{ENV['INTEGRATIONS_REPO']}"
-    })
-    sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/software.rb.erb) | erb > #{PROJECT_DIR}/config/software/dd-check-#{ENV['INTEGRATION']}-software.rb"
-
-    sh "cd #{PROJECT_DIR} && bin/omnibus build dd-check-#{ENV['INTEGRATION']} --output_manifest=false"
-  end
-
   desc 'Build an integration'
   task :'build-integration' do
     Rake::Task["agent:clean"].invoke
     Rake::Task["env:import-rpm-key"].invoke
     Rake::Task["agent:pull-integrations"].invoke
-    Rake::Task["agent:execute-script"].invoke
+    if ENV['BUILD_ALL_INTEGRATIONS'] || !ENV['INTEGRATION']
+      Rake::Task["agent:build-all-integrations"].invoke
+    elsif ENV['INTEGRATIONS']
+      checks = ENV['INTEGRATIONS'].split(',')
+      checks.each do |check|
+        ENV['INTEGRATION'] = check
+        prepare_and_execute_build(check)
+      end
+    else
+      prepare_and_execute_build(check)
+    end
   end
 
+  desc 'Build all integrations'
+  task :'build-all-integrations' do
+    checks = Dir.glob("/#{ENV['INTEGRATIONS_REPO']}/*/")
+    checks.each do |check|
+      check.slice! "/#{ENV['INTEGRATIONS_REPO']}/"
+      check.slice! "/"
+      prepare_and_execute_build(check)
+      Rake::Task["agent:clean"].invoke
+    end
+  end
 end
 
 namespace :env do
@@ -68,6 +66,46 @@ namespace :env do
   end
 end
 
+def prepare_and_execute_build(integration, dont_error_on_build: false)
+  sh "cd #{PROJECT_DIR} && bundle update"
+  puts "building integration #{integration}"
+
+  manifest = JSON.parse(File.read("/#{ENV['INTEGRATIONS_REPO']}/#{integration}/manifest.json"))
+  # The manifest should always have a version
+  integration_version = manifest['version']
+  if linux?
+    manifest['supported_os'].include?('linux') || return
+  elsif windows?
+    manifest['supported_os'].include?('windows') || return
+  elsif osx?
+    manifest['supported_os'].include?('osx') || return
+  end
+
+  header = erb_header({
+    'name' => "#{integration}",
+    'version' => "#{integration_version}",
+    'build_iteration' => "#{ENV['BUILD_ITERATION']}",
+    'integrations_repo' => "#{ENV['INTEGRATIONS_REPO']}"
+  })
+
+  sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/project.rb.erb) | erb > #{PROJECT_DIR}/config/projects/dd-check-#{ENV['INTEGRATION']}.rb"
+
+  header = erb_header({
+    'name' => "#{integration}",
+    'PROJECT_DIR' => "#{PROJECT_DIR}",
+    'integrations_repo' => "#{ENV['INTEGRATIONS_REPO']}"
+  })
+
+  sh "(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/software.rb.erb) | erb > #{PROJECT_DIR}/config/software/dd-check-#{ENV['INTEGRATION']}-software.rb"
+
+  build_cmd = "cd #{PROJECT_DIR} && bin/omnibus build dd-check-#{integration} --output_manifest=false"
+
+  if dont_error_on_build
+    build_cmd += " || true"
+  end
+  sh build_cmd
+end
+
 def erb_header(variables)
   # ERB does not support setting template variables on the command line
   # this method generates a header usable by a ERB file
@@ -76,4 +114,16 @@ def erb_header(variables)
     out += "<% #{key}=\"#{value}\" %>"
   end
   out
+end
+
+def linux?()
+  return %w(rhel debian fedora suse gentoo slackware arch exherbo).include? @ohai['platform_family']
+end
+
+def osx?()
+  return @ohai['platform_family'] == 'mac_os_x'
+end
+
+def windows?()
+  return @ohai['platform_family'] == 'windows'
 end


### PR DESCRIPTION
These changes to the rakefile will enable us to build more than one integration at once.

There are three options now:

1. It will build a single integration
1. It will build multiple specified integrations
1. It will build every integration for that platform into separate packages (it uses ohai to figure out what platform it's on)