### PR TITLE
always_build is back

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -139,12 +139,16 @@ if linux?
   # during RPM upgrades. (the old files from the RPM file listthat are not in the new RPM file
   # list will get removed, that's why we need this one here)
   extra_package_file '/usr/bin/dd-agent'
+end
 
-  # Linux-specific dependencies
+# creates required build directories - has to be the first declared dep
+dependency 'preparation'
+
+# Linux-specific dependencies
+if linux?
   dependency 'procps-ng'
   dependency 'sysstat'
 end
-
 # Ship supervisor anywhere but on Windows
 if not windows?
   dependency 'kafka-python'
@@ -173,8 +177,6 @@ end
 # Dependencies
 # ------------------------------------
 
-# creates required build directories
-dependency 'preparation'
 
 # Agent dependencies
 dependency 'boto'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -1,6 +1,7 @@
 require './lib/ostools.rb'
 
 name 'datadog-agent'
+always_build true
 
 local_agent_repo = ENV['LOCAL_AGENT_REPO']
 if local_agent_repo.nil? || local_agent_repo.empty?

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -37,13 +37,6 @@ if [ -n "$RPM_SIGNING_PASSPHRASE" ]; then
   gpg --import /keys/RPM-SIGNING-KEY.private
 fi
 
-# Last but not least, let's make sure that we rebuild the agent everytime because
-# the extra package files are destroyed when the build container stops (we have
-# to tweak omnibus-git-cache directly for that). Same for gohai and go-metro.
-git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-agent` || true
-git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-gohai` || true
-git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -d `git --git-dir=/var/cache/omnibus/cache/git_cache/opt/datadog-agent tag -l | grep datadog-metro` || true
-
 # Install the gems we need, with stubs in bin/
 bundle update # Make sure to update to the latest version of omnibus-software
 bin/omnibus build -l=$LOG_LEVEL $PROJECT_NAME


### PR DESCRIPTION
preparation is the first step, and by being the first declared, omnibus treats it specially, and will never change its place (it will always be the first to run).
always_build is back: https://github.com/DataDog/omnibus-ruby/pull/34
We can use it instead of the old hack!
See also: https://github.com/DataDog/omnibus-software/pull/104