### PR TITLE
[windows] add pedump for healthcheck

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', br
 gem 'httparty'
 gem 'win32-process'
 gem 'ohai'
+gem 'pedump', git: 'https://github.com/ksubrama/pedump', branch: 'patch-1'


### PR DESCRIPTION
Good news: it's ✅ !

This is an optional dependency of `omnibus`. The reason why we cannot
declare it as a real dependency in our fork is that we want a particular
version, from git. So we have to install it with bundler, which can only
be done in `dd-agent-omnibus`.