### PR TITLE
[preinst] if find fails, do so silently

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ bin/*
 resources/dd-check-*
 config/software/dd-check-*-software.rb
 config/projects/dd-check-*.rb
+vendor/

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -65,7 +65,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
   # of https://www.debian.org/doc/debian-policy/ch-maintainerscripts.html)
   # It is also here because version < 5.4 didn't delete .pyc,
   # so we need to be sure to clean them here (if a file is deleted for instance)
-  find $INSTALL_DIR/agent -name '*.py[co]' -type f -delete || true
+  find $INSTALL_DIR/agent -name '*.py[co]' -type f -delete 2>&1 >/dev/null || true
 
   # FIXME: remove when CentOS5 support is dropped (03/31/2017) or when everybody
   # has stopped using dd-agent 5.3 (and older versions ofc)


### PR DESCRIPTION
This line is always annoying when installing the agent:
`find: ‘/opt/datadog-agent/agent’: No such file or directory`
Let's remove it.