### PR TITLE
[windows] remove psycopg2 dep

### DIFF
--- a/config/software/integration-deps.rb
+++ b/config/software/integration-deps.rb
@@ -20,12 +20,9 @@ dependency 'python-rrdtool'
 dependency 'pyvmomi'
 dependency 'scandir'
 
-# This didn't use to be on windows.
-# We have bumped the version to one that builds successfully on windows
-dependency 'psycopg2'
-
 if not windows?
   dependency 'kafka-python'
+  dependency 'psycopg2'
   dependency 'python-gearman'
   dependency 'snakebite'
 end


### PR DESCRIPTION
The pip wheel might be Windows-compatible, but our software definition
is not. Let's double test it when we want to ship it.