### PR TITLE
skip checks that shouldn't be built on that platform

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -64,7 +64,16 @@ build do
       check.slice! "#{project_dir}/"
       check.slice! "/"
 
-      `echo #{check}`
+      # Check the manifest to be sure that this check is enabled on this system
+      # or skip this iteration
+      manifest = JSON.parse(File.read("#{project_dir}/#{check}/manifest.json"))
+      if linux?
+        manifest['supported_os'].include?('linux') || next
+      elsif windows?
+        manifest['supported_os'].include?('windows') || next
+      elsif osx?
+        manifest['supported_os'].include?('osx') || next
+      end
 
       # Copy the checks over
       if File.exists? "#{project_dir}/#{check}/check.py"


### PR DESCRIPTION
We build every integration regardless of whether or not it should be built on that platform. We probably should not do that. 

This will skip a check in the loop if the manifest doesn't include the platform it's being built on.