### PR TITLE
only add the requirement if the manifest says to use it

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -102,7 +102,7 @@ build do
         end
       end
 
-      if File.exists? "#{project_dir}/#{check}/requirements.txt"
+      if File.exists? "#{project_dir}/#{check}/requirements.txt" && manifest['use_reqs_file']
         reqs = File.open("#{project_dir}/#{check}/requirements.txt", 'r').read
         reqs.each_line do |line|
           if line[0] != '#'

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -102,7 +102,7 @@ build do
         end
       end
 
-      if File.exists? "#{project_dir}/#{check}/requirements.txt" && manifest['use_reqs_file']
+      if File.exists? "#{project_dir}/#{check}/requirements.txt" && !manifest['use_omnibus_reqs']
         reqs = File.open("#{project_dir}/#{check}/requirements.txt", 'r').read
         reqs.each_line do |line|
           if line[0] != '#'


### PR DESCRIPTION
Some integrations have requirements that do not install easily through pip on every platform. Let's not talk about why, because I don't know why protobuf won't. I just know it won't. But we can install it with a source file. So, let's use the manifest to say: don't install this from here, use omnibus.