### PR TITLE
[preinst] Check for proxy and prexisting pgp key

### DIFF
--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -34,8 +34,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
     # Prepare the GPG keys rotation:
     # Add the new one to the list of trusted APT keys.
-    # Some servers are on severely resticted networks.  Check for proxy,
-    # and check if key already exists.
+    # Some servers are on severely restricted networks.
+    # Check if key already exists.
     echo "Prepare Datadog Agent keys rotation"
     echo -n "  Add the new 'Datadog, Inc <package@datadoghq.com>' key to the list of APT trusted keys."
     if $( apt-key finger | grep -q 'A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE' ); then

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -34,10 +34,18 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
     # Prepare the GPG keys rotation:
     # Add the new one to the list of trusted APT keys.
+    # Some servers are on severely resticted networks.  Check for proxy,
+    # and check if key already exists.
     echo "Prepare Datadog Agent keys rotation"
     echo -n "  Add the new 'Datadog, Inc <package@datadoghq.com>' key to the list of APT trusted keys."
-    apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" || echo " ... failed"
-
+    if $( apt-key finger | grep -q '935F 5A43 6A5A 6E87 88F0  765B 226A E980 C7A7 DA52' ); then
+        echo "... key already installed"
+    else
+        if [ "$http_proxy" != "" ]; then
+            HKP_PROXY="--keyserver-options http-proxy=$http_proxy"
+        fi
+        apt-key adv $HKP_PROXY --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" || echo " ... failed" 
+    fi
     #DEBHELPER#
 
   elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ "$DISTRIBUTION" == "RedHat" ] || [ "$DISTRIBUTION" == "CentOS" ] || [ "$DISTRIBUTION" == "openSUSE" ] || [ "$DISTRIBUTION" == "Amazon" ] || [ "$DISTRIBUTION" == "SUSE" ]; then

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -41,10 +41,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     if $( apt-key finger | grep -q 'A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE' ); then
         echo "... key already installed"
     else
-        if [ "$http_proxy" != "" ]; then
-            HKP_PROXY="--keyserver-options http-proxy=$http_proxy"
-        fi
-        apt-key adv $HKP_PROXY --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" || echo " ... failed" 
+        apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" || echo " ... failed" 
     fi
     #DEBHELPER#
 

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -38,7 +38,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     # and check if key already exists.
     echo "Prepare Datadog Agent keys rotation"
     echo -n "  Add the new 'Datadog, Inc <package@datadoghq.com>' key to the list of APT trusted keys."
-    if $( apt-key finger | grep -q '935F 5A43 6A5A 6E87 88F0  765B 226A E980 C7A7 DA52' ); then
+    if $( apt-key finger | grep -q 'A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE' ); then
         echo "... key already installed"
     else
         if [ "$http_proxy" != "" ]; then


### PR DESCRIPTION
The current logic breaks on servers with limited connections to the internet.

Check if the key already exists.  Private Apt mirrors can provide these keys.

Alternatively, check for a proxy and apply it to the apt-key command.