### PR TITLE
[rpm][trace] Avoid using `go build -a` on CentOS 5

### DIFF
--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -54,6 +54,11 @@ build do
 
    # Build datadog-trace-agent
    command "$GOPATH/bin/glide install", :env => env, :cwd => agent_cache_dir
-   command "rake build", :env => env, :cwd => agent_cache_dir
-   command "mv ./trace-agent #{install_dir}/bin/trace-agent", :env => env, :cwd => agent_cache_dir
+   if rhel? # temporary workaround for RHEL 5 build issue with the regular `build -a` command
+     command "rake install", :env => env, :cwd => agent_cache_dir
+     command "mv $GOPATH/bin/trace-agent #{install_dir}/bin/trace-agent", :env => env, :cwd => agent_cache_dir
+   else
+     command "rake build", :env => env, :cwd => agent_cache_dir
+     command "mv ./trace-agent #{install_dir}/bin/trace-agent", :env => env, :cwd => agent_cache_dir
+   end
 end


### PR DESCRIPTION
Temp workaround to unblock our rpm build. This build is broken since https://github.com/DataDog/dd-agent-omnibus/pull/148

See https://circleci.com/gh/DataDog/docker-dd-agent-build-rpm-x64/1694 for an example of a build that failed with `go build -a`

cc @galdor: Could you have a look into this and see if there's a better solution?