### PR TITLE
[pyodbc] Add dep to integration-deps

### DIFF
--- a/config/software/integration-deps.rb
+++ b/config/software/integration-deps.rb
@@ -26,4 +26,6 @@ if not windows?
   dependency 'psycopg2'
   dependency 'python-gearman'
   dependency 'snakebite'
+else
+  dependency 'pyodbc'
 end


### PR DESCRIPTION
Only on Windows since an additional dep is required on Linux (see #129)