### PR TITLE
[python] Extract removal of python-compiled files to separate def

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -179,5 +179,10 @@ end
 # Datadog agent
 dependency 'datadog-agent'
 dependency 'datadog-agent-integrations'
+
+# version manifest file
+# should be built after all the other dependencies
+dependency 'version-manifest'
+
 exclude '\.git*'
 exclude 'bundler\/git'

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -180,6 +180,12 @@ end
 dependency 'datadog-agent'
 dependency 'datadog-agent-integrations'
 
+# Remove pyc/pyo files from package
+# should be built after all the other python-related software defs
+if linux?
+  dependency 'py-compiled-cleanup'
+end
+
 # version manifest file
 # should be built after all the other dependencies
 dependency 'version-manifest'

--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -47,6 +47,3 @@ dependency 'uuid'
 # Check dependencies
 # psutil is required by the core agent on Windows
 dependency 'integration-deps'
-
-# version manifest file
-dependency 'version-manifest'

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -78,11 +78,6 @@ build do
     mkdir '/etc/dd-agent/checks.d/'
     command 'chmod 755 /etc/init.d/datadog-agent'
     touch '/usr/bin/dd-agent'
-
-    # Remove the .pyc and .pyo files from the package and list them in a file
-    # so that the prerm script knows which compiled files to remove
-    command "echo '# DO NOT REMOVE/MODIFY - used by package removal tasks' > #{install_dir}/embedded/.py_compiled_files.txt"
-    command "find #{install_dir}/embedded '(' -name '*.pyc' -o -name '*.pyo' ')' -type f -delete -print >> #{install_dir}/embedded/.py_compiled_files.txt"
   end
 
   if osx?


### PR DESCRIPTION
This step has to be done at the end of the build to ensure it works well, so it makes sense to extract it. Related PR on omnibus-software: https://github.com/DataDog/omnibus-software/pull/130

Also, move `version-manifest` to the very end of the build.

I've run builds against this branch and made sure that the resulting RPM pkg doesn't output errors on removal anymore