### PR TITLE
Fixes SDK Building

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -112,7 +112,7 @@ def prepare_and_execute_build(integration, dont_error_on_build: false)
 
   #`(echo '#{header}' && cat #{PROJECT_DIR}/resources/datadog-integrations/project.rb.erb) | erb > #{PROJECT_DIR}/config/projects/dd-check-#{integration}.rb`
   sh "(echo \"#{header}\" && cat #{PROJECT_DIR}/resources/datadog-integrations/project.rb.erb) | erb > #{PROJECT_DIR}/config/projects/dd-check-#{integration}.rb"
-  
+
   header = erb_header({
     'name' => "#{integration}",
     'project_dir' => "#{PROJECT_DIR}",
@@ -145,7 +145,7 @@ def erb_header(variables)
   # this method generates a header usable by a ERB file
   out = ""
   variables.each do |key, value|
-    out += "<% #{key}=\"#{value}\" %>"
+    out += "<% #{key}='#{value}' %>"
   end
   out
 end


### PR DESCRIPTION
The Linux SDK build currently has a strange error in it: 

```
(echo "<% name="powerdns_recursor" %><% version="1.0.0" %><% build_iteration="1" %><% integrations_repo="integrations-core" %><% guid="ae533b67-a2af-45ce-8e23-235acb3a3893" %><% description="" %>" && cat /dd-age
nt-omnibus/resources/datadog-integrations/project.rb.erb) | erb > /dd-agent-omnibus/config/projects/dd-check-powerdns_recursor.rb
/usr/local/rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/erb.rb:863:in `eval': -:1: unexpected fraction part after numeric literal (SyntaxError)
...owerdns_recursor ;  version=1.0.0 ;  build_iteration=1 ;  in...
...                               ^
-:1: syntax error, unexpected tIDENTIFIER, expecting end-of-input
...core ;  guid=ae533b67-a2af-45ce-8e23-235acb3a3893 ;  descrip...
...                               ^
        from /usr/local/rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/erb.rb:863:in `result'
        from /usr/local/rvm/rubies/ruby-2.2.2/lib/ruby/2.2.0/erb.rb:845:in `run'
        from /usr/local/rvm/rubies/ruby-2.2.2/bin/erb:149:in `run'
        from /usr/local/rvm/rubies/ruby-2.2.2/bin/erb:170:in `<main>'
rake aborted!
```

It seems like something is going wrong with the escaping, this appears to fix it.