### PR TITLE
[windows] Fix check for previous versions, otherwise upgrade of same

### DIFF
--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -36,7 +36,7 @@
         <UpgradeVersion OnlyDetect='no'
                         Property='PREVIOUSFOUND'
                         Minimum='1.0.0' IncludeMinimum='yes'
-                        Maximum="$(var.DisplayVersionNumber)" IncludeMaximum='no'/>
+                        Maximum="99.99.99.99" IncludeMaximum='no'/>
     </Upgrade>
     <!-- This removes entirely the previous version -->
     <Upgrade Id="$(var.PerUserUpgradeCode)">
@@ -58,9 +58,12 @@
     <!-- No need to restart Windows after the installation -->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
-    <!-- Make sure that we get rid of any older installation of the Agent -->
+        <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
+      same version gets installed "side by side" -->
+
     <MajorUpgrade
-      DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
+      AllowDowngrades="yes"
+     />
 
     <Media Id="1" Cabinet="agent.cab" EmbedCab="yes" />
 

--- a/resources/datadog-integrations/msi/source.wxs.erb
+++ b/resources/datadog-integrations/msi/source.wxs.erb
@@ -54,10 +54,11 @@
     <!-- No need to restart Windows after the installation -->
     <Property Id="MSIRESTARTMANAGERCONTROL" Value="Disable" />
 
-    <!-- Make sure that we get rid of any older installation of the Agent -->
+    <!-- This allows downgrades, and same-version reinstalls.  Otherwise,
+      same version gets installed "side by side" -->
     <MajorUpgrade
-      DowngradeErrorMessage="A later version of [ProductName] is already installed. Setup will now exit." />
-
+      AllowDowngrades="yes"
+     />
     <Media Id="1" Cabinet="agent.cab" EmbedCab="yes" />
 
     <Directory Id="TARGETDIR" Name="SourceDir">


### PR DESCRIPTION
version doesn't work.

Had inadvertently removed the allowDowngrades flag, which also makes it possible to install the same version side by side.  

Now can upgrade & downgrade.