### PR TITLE
[datadog-agent-integrations] remove install-script

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -115,7 +115,7 @@ build do
     # Close the checks requirements file
     all_reqs_file.close
 
-  pip_cmd = "install --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" -c #{install_dir}/agent/requirements.txt -r /check_requirements.txt"
+  pip_cmd = "install -c #{install_dir}/agent/requirements.txt -r /check_requirements.txt"
   if windows?
     inst_cmd = "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe " + pip_cmd
     command inst_cmd

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -115,17 +115,11 @@ build do
     # Close the checks requirements file
     all_reqs_file.close
 
-  pip_cmd = "install -c #{install_dir}/agent/requirements.txt -r /check_requirements.txt"
-  if windows?
-    inst_cmd = "#{windows_safe_path(install_dir)}\\embedded\\scripts\\pip.exe " + pip_cmd
-    command inst_cmd
-  else
     build_env = {
       "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
       "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
     }
-    command "pip #{pip_cmd}", :env => build_env
-  end
+    pip "install -c #{install_dir}/agent/requirements.txt -r /check_requirements.txt", env: build_env
 
     copy '/check_requirements.txt', "#{install_dir}/agent/"
   end


### PR DESCRIPTION
Because the psycopg2 upgrade to 2.7.1 broke master.
It is safe for two reasons:
- checks don't (and shouldn't) rely on CLIs to use python modules.
- the default scripts location is #{install_dir}/embedded/bin, and is
  added to the path by the diverse init scripts.

And also: use the pip DSL, it's already cross-platform.