### PR TITLE
Add flag to allow skipping of the upgrade test

### DIFF
--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -21,6 +21,7 @@
     <Variable Name="APIKEY" bal:Overridable="yes"/>
     <Variable Name="TAGS" bal:Overridable="yes"/>
     <Variable Name="HOSTNAME" bal:Overridable="yes"/>
+    <Variable Name="NOTUPGRADE" bal:Overridable="yes"/>
 		
     <Chain>
       <ExePackage
@@ -42,6 +43,7 @@
         <MsiProperty Name="APIKEY" Value="[APIKEY]"/>
         <MsiProperty Name="TAGS" Value="[TAGS]"/>
         <MsiProperty Name="HOSTNAME" Value="[HOSTNAME]"/>
+        <MsiProperty Name="NOTUPGRADE" Value="[NOTUPGRADE]"/>
       </MsiPackage>
 		</Chain>
 	</Bundle>

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -247,7 +247,7 @@
       <Custom Action="WixCloseApplications"
           After="InstallInitialize"><![CDATA[REMOVE="ALL" OR REINSTALL]]></Custom>
       <Custom Action="CheckForOldVersion"
-          After="InstallInitialize"><![CDATA[NOT Installed AND NOT REMOVE]]></Custom>
+          After="InstallInitialize"><![CDATA[NOT Installed AND NOT REMOVE AND NOT NOTUPGRADE]]></Custom>
     </InstallExecuteSequence>
     <!-- UI Stuff: 100% Omnibus Generated -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>


### PR DESCRIPTION
There have been a few support issues where the check for the previous, per-user install fails.  Provide a flag to skip that check, to give support a workaround in these specific cases.

This flag is only to be used when it's known that this is a new install.