### PR TITLE
Add flag to allow skipping of the upgrade test

### DIFF
--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -24,6 +24,7 @@
     <Variable Name="APIKEY" bal:Overridable="yes"/>
     <Variable Name="TAGS" bal:Overridable="yes"/>
     <Variable Name="HOSTNAME" bal:Overridable="yes"/>
+    <Variable Name="NOTUPGRADE" bal:Overridable="yes"/>
 		
     <Chain>
       <ExePackage
@@ -45,6 +46,7 @@
         <MsiProperty Name="APIKEY" Value="[APIKEY]"/>
         <MsiProperty Name="TAGS" Value="[TAGS]"/>
         <MsiProperty Name="HOSTNAME" Value="[HOSTNAME]"/>
+        <MsiProperty Name="NOTUPGRADE" Value="[NOTUPGRADE]"/>
       </MsiPackage>
 		</Chain>
 	</Bundle>

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -247,7 +247,7 @@
       <Custom Action="WixCloseApplications"
           After="InstallInitialize"><![CDATA[REMOVE="ALL" OR REINSTALL]]></Custom>
       <Custom Action="CheckForOldVersion"
-          After="InstallInitialize"><![CDATA[NOT Installed AND NOT REMOVE]]></Custom>
+          After="InstallInitialize"><![CDATA[NOT Installed AND NOT REMOVE AND NOT NOTUPGRADE]]></Custom>
     </InstallExecuteSequence>
     <!-- UI Stuff: 100% Omnibus Generated -->
     <Icon Id="project.ico" SourceFile="Resources\assets\project_16x16.ico"/>


### PR DESCRIPTION
same commit as 5.12.x; did the commit/cherry-pick backwards.