### PR TITLE
[datadog-agent] Use option to always fetch tags

### DIFF
--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -5,7 +5,7 @@ always_build true
 
 local_agent_repo = ENV['LOCAL_AGENT_REPO']
 if local_agent_repo.nil? || local_agent_repo.empty?
-  source git: 'https://github.com/DataDog/dd-agent.git'
+  source git: 'https://github.com/DataDog/dd-agent.git', always_fetch_tags: true
 else
   # For local development
   source path: ENV['LOCAL_AGENT_REPO']


### PR DESCRIPTION
Related to https://github.com/DataDog/omnibus-ruby/pull/41

Should finally ensure that we always pull the latest tag that's on the remote even when the cache already has the latest commit. And this should allow us to never clear the cache for tag-related reasons.