### PR TITLE
removes reliance on pedump fork

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', br
 gem 'httparty'
 gem 'win32-process'
 gem 'ohai'
-gem 'pedump'
+gem 'pedump', '~> 0.5.0'
 gem 'rake', '~> 11.0'

--- a/Gemfile
+++ b/Gemfile
@@ -4,5 +4,5 @@ gem 'omnibus-software', git: 'git://github.com/datadog/omnibus-software.git', br
 gem 'httparty'
 gem 'win32-process'
 gem 'ohai'
-gem 'pedump', git: 'https://github.com/ksubrama/pedump', branch: 'patch-1'
+gem 'pedump'
 gem 'rake', '~> 11.0'


### PR DESCRIPTION
We were relying on a fork made by a chef employee. He deleted his repo, making pedump fail, this restores it: https://github.com/chef/omnibus/commit/825d94f957cedb44de025b0b10f7ff007d383d08