### PR TITLE
Whitelists agent files

### DIFF
--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -82,6 +82,7 @@ runtime_dependency 'datadog-agent'
 unless ohai['platform'] == "windows"
   #extends_packages not supported by Omnibus on Windows
   extends_packages('datadog-agent', 'datadog')
+  whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
 end
 
 license_file_path "licenses/dd-check-<%= name %>"

--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -82,7 +82,6 @@ runtime_dependency 'datadog-agent'
 unless ohai['platform'] == "windows"
   #extends_packages not supported by Omnibus on Windows
   extends_packages('datadog-agent', 'datadog')
-  whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
 end
 
 license_file_path "licenses/dd-check-<%= name %>"

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -8,6 +8,7 @@ if windows?
   require_relative "../../resources/datadog-integrations/validate_manifest"
 else
   require_relative "<%= project_dir %>/resources/datadog-integrations/validate_manifest"
+    whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
 end
 
 integration_source_folder = '/<%= integrations_repo %>/<%= name %>'

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -8,7 +8,7 @@ if windows?
   require_relative "../../resources/datadog-integrations/validate_manifest"
 else
   require_relative "<%= project_dir %>/resources/datadog-integrations/validate_manifest"
-  whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
+  whitelist_file /\/opt\/datadog-agent\/embedded\/.+\.so.+/
 end
 
 integration_source_folder = '/<%= integrations_repo %>/<%= name %>'

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -8,7 +8,7 @@ if windows?
   require_relative "../../resources/datadog-integrations/validate_manifest"
 else
   require_relative "<%= project_dir %>/resources/datadog-integrations/validate_manifest"
-    whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
+  whitelist_file /\/opt\/datadog-agent\/.+\.so.+/
 end
 
 integration_source_folder = '/<%= integrations_repo %>/<%= name %>'


### PR DESCRIPTION
Omnibus doesn't think that the libraries will be there, so it fails the health checks. It shouldn't, though, it should pass them.