### PR TITLE
RPM should not have dist tag on integrations

### DIFF
--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -41,6 +41,7 @@ description '<%= name %> Integration for Datadog Monitoring Agent
 # .deb specific flags
 package :deb do
   vendor 'Datadog <info@datadoghq.com>'
+  epoch 1
   license 'Simplified BSD License'
   section 'utils'
   priority 'extra'
@@ -49,6 +50,8 @@ end
 # .rpm specific flags
 package :rpm do
   vendor 'Datadog <package@datadoghq.com>'
+  epoch 1
+  dist_tag ''
   license 'Simplified BSD License'
   category 'System Environment/Daemons'
   priority 'extra'


### PR DESCRIPTION
RPM integration packages are mistakenly marked with a dist tag, this will remove that.