### PR TITLE
Add datadog-process-agent to build

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ See:
 ```bash
 PLATFORM="deb-x64" # must be in "deb-x64", "deb-i386", "rpm-x64", "rpm-i386"
 TRACE_AGENT_BRANCH="master" # Branch of the datadog-trace-agent repo to use, default "master"
+PROCESS_AGENT_BRANCH="master" # Branch of the datadog-process-agent repo to use, default "master"
 AGENT_BRANCH="master" # Branch of dd-agent repo to use, default "master"
 OMNIBUS_BRANCH="master" # Branch of dd-agent-omnibus repo to use, default "master"
 AGENT_VERSION="5.4.0" # default to the latest tag on that branch
@@ -45,6 +46,7 @@ docker run --name "dd-agent-build-$PLATFORM" \
   -e AGENT_BRANCH=$AGENT_BRANCH \
   -e AGENT_VERSION=$AGENT_VERSION \
   -e TRACE_AGENT_BRANCH=$TRACE_AGENT_BRANCH \
+  -e PROCESS_AGENT_BRANCH=$PROCESS_AGENT_BRANCH \
   -e RPM_SIGNING_PASSPHRASE=$RPM_SIGNING_PASSPHRASE \
   -e LOCAL_AGENT_REPO=$LOCAL_AGENT_REPO # Only to use if you want to build from a local repo \
   -v `pwd`/pkg:/dd-agent-omnibus/pkg \

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -175,6 +175,7 @@ if windows?
 end
 if linux?
   dependency 'datadog-trace-agent'
+  dependency 'datadog-process-agent'
 end
 
 # Datadog agent

--- a/config/software/datadog-process-agent.rb
+++ b/config/software/datadog-process-agent.rb
@@ -1,0 +1,18 @@
+name "datadog-process-agent"
+always_build true
+
+process_agent_branch = ENV['PROCESS_AGENT_BRANCH']
+if process_agent_branch.nil? || process_agent_branch.empty?
+    process_agent_branch = "master"
+end
+default_version process_agent_branch
+
+
+build do
+  # FIXME (conor): Add ship_license once repo is open source
+  binary = "process-agent-amd64-#{version}"
+  url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
+  command "curl #{url} -o #{binary}"
+  command "chmod +x #{binary}"
+  command "mv #{binary} #{install_dir}/bin/process-agent"
+end 


### PR DESCRIPTION
Following the release process docs (https://github.com/DataDog/devops/wiki/Process-Agent#dd-agent-release-process) we will be building a statically-linked binary with our own build environment and omnibus will pull it in based on the chosen branch.

cc @shang-wang 