### PR TITLE
do not install pip deps for some integrations

### DIFF
--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -45,7 +45,7 @@ namespace :agent do
     # if someone forgets to set INTEGRATIONS_REPO
     raise 'INTEGRATIONS_REPO not set!' unless ENV['INTEGRATIONS_REPO']
     sh "rm -rf #{FSROOT}#{ENV['INTEGRATIONS_REPO']}"
-    
+
     sh "git clone https://github.com/DataDog/#{ENV['INTEGRATIONS_REPO']}.git /#{ENV['INTEGRATIONS_REPO']} || true"
     sh "cd /#{ENV['INTEGRATIONS_REPO']} && git checkout #{integration_branch}"
     sh "cd /#{ENV['INTEGRATIONS_REPO']} && git fetch --all"
@@ -71,11 +71,14 @@ namespace :agent do
   desc 'Build all integrations'
   task :'build-all-integrations' do
     checks = Dir.glob("/#{ENV['INTEGRATIONS_REPO']}/*/")
+    skip_checks = ENV['SKIP_INTEGRATION'].split(',')
     checks.each do |check|
       check.slice! "/#{ENV['INTEGRATIONS_REPO']}/"
       check.slice! "/"
-      prepare_and_execute_build(check)
-      Rake::Task["agent:clean"].invoke
+      unless skip_checks.include? check
+        prepare_and_execute_build(check)
+        Rake::Task["agent:clean"].invoke
+      end
     end
   end
 end

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -71,7 +71,11 @@ namespace :agent do
   desc 'Build all integrations'
   task :'build-all-integrations' do
     checks = Dir.glob("/#{ENV['INTEGRATIONS_REPO']}/*/")
-    skip_checks = ENV['SKIP_INTEGRATION'].split(',')
+    if ENV['SKIP_INTEGRATION']
+      skip_checks = ENV['SKIP_INTEGRATION'].split(',')
+    else
+      skip_checks = []
+    end
     checks.each do |check|
       check.slice! "/#{ENV['INTEGRATIONS_REPO']}/"
       check.slice! "/"

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -72,7 +72,7 @@ namespace :agent do
   task :'build-all-integrations' do
     checks = Dir.glob("/#{ENV['INTEGRATIONS_REPO']}/*/")
     if ENV['SKIP_INTEGRATION']
-      skip_checks = ENV['SKIP_INTEGRATION'].split(',')
+      skip_checks = ENV['SKIP_INTEGRATION'].split(',').map(&:strip)
     else
       skip_checks = []
     end

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -53,7 +53,7 @@ build do
   end
 
   if File.exists? "#{integration_source_folder}/requirements.txt"
-    unless manifest.key?("package_deps") && ! manifest["package_deps"]
+    if manifest.key?("package_deps") && manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "
       # Only apply the constraints file if one exists

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -62,6 +62,9 @@ build do
     Omnibus.logger.info("thingy") {
        manifest["package_deps"]
     }
+    Omnibus.logger.info("thingy") {
+       manifest.key? "package_deps" && !manifest["package_deps"]
+    }
     unless manifest.key? "package_deps" && !manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -53,18 +53,6 @@ build do
   end
 
   if File.exists? "#{integration_source_folder}/requirements.txt"
-    Omnibus.logger.info("thingy") {
-      manifest
-    }
-    Omnibus.logger.info("thingy") {
-       manifest.key? "package_deps"
-    }
-    Omnibus.logger.info("thingy") {
-       manifest["package_deps"]
-    }
-    Omnibus.logger.info("thingy") {
-       manifest.key?("package_deps") && ! manifest["package_deps"]
-    }
     unless manifest.key?("package_deps") && ! manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -52,9 +52,8 @@ build do
     copy "#{integration_source_folder}/#{file}", "#{integration_agent_folder}/#{file}"
   end
 
-
-  if File.exists? "#{integration_source_folder}/requirements.txt"
-    if integrations_repo != "integrations-core"
+  <% if integrations_repo != "integrations-core" %>
+    if File.exists? "#{integration_source_folder}/requirements.txt"
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "
       # Only apply the constraints file if one exists
@@ -76,5 +75,5 @@ build do
         command "CHDIR #{install_dir} & del /Q /S *.chm"
       end
     end
-  end
+  <% end %>
 end

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -56,6 +56,12 @@ build do
     Omnibus.logger.info("thingy") {
       manifest
     }
+    Omnibus.logger.info("thingy") {
+       manifest.key? "package_deps"
+    }
+    Omnibus.logger.info("thingy") {
+       manifest["package_deps"]
+    }
     unless manifest.key? "package_deps" && !manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -63,9 +63,9 @@ build do
        manifest["package_deps"]
     }
     Omnibus.logger.info("thingy") {
-       manifest.key? "package_deps" && !manifest["package_deps"]
+       manifest.key?("package_deps") && ! manifest["package_deps"]
     }
-    unless manifest.key? "package_deps" && !manifest["package_deps"]
+    unless manifest.key?("package_deps") && ! manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "
       # Only apply the constraints file if one exists

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -53,6 +53,9 @@ build do
   end
 
   if File.exists? "#{integration_source_folder}/requirements.txt"
+    Omnibus.logger.info("thingy") {
+      manifest
+    }
     unless manifest.key? "package_deps" && !manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -52,8 +52,8 @@ build do
     copy "#{integration_source_folder}/#{file}", "#{integration_agent_folder}/#{file}"
   end
 
-  <% if integrations_repo != "integrations-core" %>
-    if File.exists? "#{integration_source_folder}/requirements.txt"
+  if File.exists? "#{integration_source_folder}/requirements.txt"
+    unless manifest.key? "package_deps" && !manifest["package_deps"]
       # install requirements
       install_cmd = "install --target=#{integration_agent_folder}/lib "
       # Only apply the constraints file if one exists
@@ -75,5 +75,5 @@ build do
         command "CHDIR #{install_dir} & del /Q /S *.chm"
       end
     end
-  <% end %>
+  end
 end

--- a/resources/datadog-integrations/software.rb.erb
+++ b/resources/datadog-integrations/software.rb.erb
@@ -54,25 +54,27 @@ build do
 
 
   if File.exists? "#{integration_source_folder}/requirements.txt"
-    # install requirements
-    install_cmd = "install --target=#{integration_agent_folder}/lib "
-    # Only apply the constraints file if one exists
-    if File.exists? "#{install_dir}/agent/requirements.txt"
-      install_cmd += " -c #{install_dir}/agent/requirements.txt "
-    end
-    install_cmd += " -r #{integration_source_folder}/requirements.txt"
+    if integrations_repo != "integrations-core"
+      # install requirements
+      install_cmd = "install --target=#{integration_agent_folder}/lib "
+      # Only apply the constraints file if one exists
+      if File.exists? "#{install_dir}/agent/requirements.txt"
+        install_cmd += " -c #{install_dir}/agent/requirements.txt "
+      end
+      install_cmd += " -r #{integration_source_folder}/requirements.txt"
 
-    build_env = {
-      "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-      "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
-    }
-    if not windows?
-      command "pip #{install_cmd}", :env => build_env
-    else
-      install_cmd = '"C:\Program Files\Datadog\Datadog Agent\embedded\python.exe"' + ' -m pip ' + install_cmd
-      command install_cmd
-      command "CHDIR #{install_dir} & del /Q /S *.pyc"
-      command "CHDIR #{install_dir} & del /Q /S *.chm"
+      build_env = {
+        "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+        "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
+      }
+      if not windows?
+        command "pip #{install_cmd}", :env => build_env
+      else
+        install_cmd = '"C:\Program Files\Datadog\Datadog Agent\embedded\python.exe"' + ' -m pip ' + install_cmd
+        command install_cmd
+        command "CHDIR #{install_dir} & del /Q /S *.pyc"
+        command "CHDIR #{install_dir} & del /Q /S *.chm"
+      end
     end
   end
 end


### PR DESCRIPTION
This should fix the integrations issue. It is not a great solution: I would vastly prefer to be able to do ship them with upgraded dependencies. However, this is the solution we have. So, as sad as I am at the moment to give up the dream of shipping updated deps, it's all we can do. 😢 