### PR TITLE
Adding gnupg and dirmngr to allow install on debian 9

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -109,6 +109,9 @@ elsif debian?
   replace 'datadog-agent-base (<< 5.0.0)'
   replace 'datadog-agent-lib (<< 5.0.0)'
   conflict 'datadog-agent-base (<< 5.0.0)'
+  # needed starting debian 9
+  runtime_dependency 'gnupg'
+  runtime_dependency 'dirmngr'
 end
 
 # ------------------------------------


### PR DESCRIPTION
Linked to: https://github.com/DataDog/dd-agent/issues/3397

Debian 9 is missing by default packages to use `apt-key`.