### PR TITLE
Adding gnupg to allow install on debian 9 and a warning if dirmngr is not installed

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -109,6 +109,8 @@ elsif debian?
   replace 'datadog-agent-base (<< 5.0.0)'
   replace 'datadog-agent-lib (<< 5.0.0)'
   conflict 'datadog-agent-base (<< 5.0.0)'
+  # needed starting debian 9
+  runtime_dependency 'gnupg'
 end
 
 # ------------------------------------

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -42,7 +42,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     if $( apt-key finger | grep -q 'A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE' ); then
         echo "... key already installed"
     else
-        apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" || echo " ... failed"
+        apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" \
+            ||  printf " ... failed\nWARNING: If you are running Debian 9, the \"dirmngr\" package is needed to install the new APT key required by future versions of the Agent.\nIf this package is not installed, please install it and then re-install the agent. The agent installation may break in the future if the new APT key is not installed on your system\n"
     fi
     #DEBHELPER#
 


### PR DESCRIPTION
We don't enforce dependency to dirmngr on the .deb package since it's
shared between ubuntu and debian and it's only available in the
'universe' repo in ubuntu <= 14.04.

Packaging for debian and ubuntu will be split in future version of the
agent.

see: https://github.com/DataDog/dd-agent/issues/3397