### PR TITLE
Allow proxy configuration to be specified on the command line.

### DIFF
--- a/resources/datadog-agent/msi/bundle.wxs.erb
+++ b/resources/datadog-agent/msi/bundle.wxs.erb
@@ -25,6 +25,11 @@
     <Variable Name="TAGS" bal:Overridable="yes"/>
     <Variable Name="HOSTNAME" bal:Overridable="yes"/>
     <Variable Name="NOTUPGRADE" bal:Overridable="yes"/>
+    <Variable Name="PROXY_HOST" bal:Overridable="yes"/>
+    <Variable Name="PROXY_PORT" bal:Overridable="yes"/>
+    <Variable Name="PROXY_USER" bal:Overridable="yes"/>
+    <Variable Name="PROXY_PASSWORD" bal:Overridable="yes"/>
+
 		
     <Chain>
       <ExePackage
@@ -47,6 +52,10 @@
         <MsiProperty Name="TAGS" Value="[TAGS]"/>
         <MsiProperty Name="HOSTNAME" Value="[HOSTNAME]"/>
         <MsiProperty Name="NOTUPGRADE" Value="[NOTUPGRADE]"/>
+        <MsiProperty Name="PROXY_HOST" Value="[PROXY_HOST]"/>
+        <MsiProperty Name="PROXY_PORT" Value="[PROXY_PORT]"/>
+        <MsiProperty Name="PROXY_USER" Value="[PROXY_USER]"/>
+        <MsiProperty Name="PROXY_PASSWORD" Value="[PROXY_PASSWORD]"/>
       </MsiPackage>
 		</Chain>
 	</Bundle>

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -134,6 +134,18 @@
           <RegistryValue Name="hostname"
                          Type="string"
                          Value="[HOSTNAME]" />
+          <RegistryValue Name="proxy_host"
+                         Type="string"
+                         Value="[PROXY_HOST]" />
+          <RegistryValue Name="proxy_port"
+                         Type="string"
+                         Value="[PROXY_PORT]" />
+          <RegistryValue Name="proxy_user"
+                         Type="string"
+                         Value="[PROXY_USER]" />
+          <RegistryValue Name="proxy_password"
+                         Type="string"
+                         Value="[PROXY_PASSWORD]" />
         </RegistryKey>
       </Component>
     </DirectoryRef>


### PR DESCRIPTION
Allows proxy configuration to be configured on the MSI install command line

Requires companion PR https://github.com/DataDog/dd-agent/pull/3470