### PR TITLE
removes an unneded chown

### DIFF
--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -79,7 +79,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
 
   # Create symlinks to the various agent's components
   ln -sf $INSTALL_DIR/agent/agent.py /usr/bin/dd-agent
-  chown -R dd-agent:dd-agent /usr/bin/dd-agent
   chmod 755 /usr/bin/dd-agent
 
   # The configcheck call will return zero if the config is valid, which means we


### PR DESCRIPTION
There's no reason for `/usr/bin/dd-agent` to be the `dd-agent` user/group.