### PR TITLE
[centos] Improve systemd and service restart behaviors

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -125,9 +125,9 @@ if linux?
     extra_package_file '/lib/systemd/system/datadog-agent.service'
   end
 
-  # SysVInit service file
   if redhat?
     extra_package_file '/etc/rc.d/init.d/datadog-agent'
+    extra_package_file '/usr/lib/systemd/system/datadog-agent.service'
   end
 
   if suse?

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -46,24 +46,25 @@ build do
   if linux?
     # Configuration files
     mkdir '/etc/dd-agent'
-    if redhat?
-      copy 'packaging/centos/datadog-agent.init', '/etc/rc.d/init.d/datadog-agent'
-    end
 
-    if suse? || debian?
-      if debian?
-        sys_type = 'debian'
-        systemd_directory = '/lib/systemd/system'
-      elsif suse?
-        sys_type = 'suse'
-        systemd_directory = '/usr/lib/systemd/system'
-      end
-      copy "packaging/#{sys_type}/datadog-agent.init", '/etc/init.d/datadog-agent'
-      mkdir systemd_directory
-      copy 'packaging/debian/datadog-agent.service', "#{systemd_directory}/datadog-agent.service"
-      copy 'packaging/debian/start_agent.sh', '/opt/datadog-agent/bin/start_agent.sh'
-      command 'chmod 755 /opt/datadog-agent/bin/start_agent.sh'
+    if debian?
+      sys_type = 'debian'
+      systemd_directory = '/lib/systemd/system'
+      initd_directory = '/etc/init.d'
+    elsif redhat?
+      sys_type = 'centos'
+      systemd_directory = '/usr/lib/systemd/system'
+      initd_directory = '/etc/rc.d/init.d'
+    elsif suse?
+      sys_type = 'suse'
+      systemd_directory = '/usr/lib/systemd/system'
+      initd_directory = '/etc/init.d'
     end
+    copy "packaging/#{sys_type}/datadog-agent.init", "#{initd_directory}/datadog-agent"
+    mkdir systemd_directory
+    copy 'packaging/datadog-agent.service', "#{systemd_directory}/datadog-agent.service"
+    copy 'packaging/start_agent.sh', "#{install_dir}/bin/start_agent.sh"
+    command "chmod 755 #{install_dir}/bin/start_agent.sh"
 
     # Use a supervisor conf with go-metro on 64-bit platforms only
     if ohai['kernel']['machine'] == 'x86_64'

--- a/package-scripts/datadog-agent/postinst
+++ b/package-scripts/datadog-agent/postinst
@@ -23,6 +23,11 @@ fi
 
 # Linux installation
 if [ "$DISTRIBUTION" != "Darwin" ]; then
+  # Detect distribution family once
+  if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
+      DISTRIBUTION_FAMILY="Debian"
+  fi
+
   # Linus specific variables
   CONFIG_DIR=/etc/dd-agent
 
@@ -34,7 +39,7 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
       rm /etc/supervisor/conf.d/ddagent.conf
   fi
 
-  if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIBUTION" = "Ubuntu" ]; then
+  if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
       set -e
       case "$1" in
           configure)
@@ -81,34 +86,40 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
   ln -sf $INSTALL_DIR/agent/agent.py /usr/bin/dd-agent
   chmod 755 /usr/bin/dd-agent
 
+
+  # Restart the agent here on Debian platforms.
+  # On RHEL, the restart is done in the posttrans script.
+
   # The configcheck call will return zero if the config is valid, which means we
   # can restart the agent without taking the risk to trigger an error in the
   # postinst script . If the config file doesn't exist (RETVAL=3), the user is
   # probably using the source install script so let's consider the postinst script
-  # did its job and exist zero, otherwise, if the file exists but it's wrong we
+  # did its job and exits zero, otherwise, if the file exists but it's wrong we
   # have to return a non zero exit status so that the system (and the user) are
   # notified the installation went wrong.
-  /etc/init.d/datadog-agent configcheck > /dev/null 2>&1
-  RETVAL=$?
-  if [ $RETVAL -eq 0 ]; then
-      echo "(Re)starting datadog-agent now..."
-      if command -v invoke-rc.d >/dev/null 2>&1; then
-          invoke-rc.d datadog-agent restart
-      else
-          /etc/init.d/datadog-agent restart
+  if [ "$DISTRIBUTION_FAMILY" = "Debian" ]; then
+      /etc/init.d/datadog-agent configcheck > /dev/null 2>&1
+      RETVAL=$?
+      if [ $RETVAL -eq 0 ]; then
+          echo "(Re)starting datadog-agent now..."
+          if command -v invoke-rc.d >/dev/null 2>&1; then
+              invoke-rc.d datadog-agent restart
+          else
+              /etc/init.d/datadog-agent restart
+          fi
+      fi
+      if [ $RETVAL -ne 0 ]; then
+          if [ $RETVAL -eq 3 ]; then
+              # No datadog.conf file is present. The user is probably following
+              # the step-by-step instructions and will add the config file next.
+              exit 0
+          else
+              echo "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configcheck for more details."
+              exit $RETVAL
+          fi
       fi
   fi
 
-  if [ $RETVAL -ne 0 ]; then
-      if [ $RETVAL -eq 3 ]; then
-          # No datadog.conf file is present. The user is probably following
-          # the step-by-step instructions and will add the config file next.
-          exit 0
-      else
-          echo "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configcheck for more details."
-          exit $RETVAL
-      fi
-  fi
 # OSX installation
 elif [ "$DISTRIBUTION" = "Darwin" ]; then
   # OSX specific variables

--- a/package-scripts/datadog-agent/posttrans
+++ b/package-scripts/datadog-agent/posttrans
@@ -8,5 +8,21 @@ getent group dd-agent >/dev/null || groupadd -r dd-agent
 getent passwd dd-agent >/dev/null || \
     useradd -r -M -g dd-agent -d /usr/share/datadog/agent -s /bin/sh \
     -c "Datadog Agent" dd-agent
-/etc/init.d/datadog-agent restart
-exit 0
+
+# See comment in postinst script for an explanation of the logic below
+/etc/init.d/datadog-agent configcheck > /dev/null 2>&1
+RETVAL=$?
+if [ $RETVAL -eq 0 ]; then
+  echo "(Re)starting datadog-agent now..."
+  /etc/init.d/datadog-agent restart
+fi
+if [ $RETVAL -ne 0 ]; then
+  if [ $RETVAL -eq 3 ]; then
+      # No datadog.conf file is present. The user is probably following
+      # the step-by-step instructions and will add the config file next.
+      exit 0
+  else
+      echo "Invalid check configuration. Please run sudo /etc/init.d/datadog-agent configcheck for more details."
+      exit $RETVAL
+  fi
+fi


### PR DESCRIPTION
Depends on https://github.com/DataDog/dd-agent/pull/3477

* Improves service restart logic in installation scripts: on CentOS instead of restarting the agent service both in `postinst` and `posttrans`, only restart it in `posttrans`, and make sure a `datadog.conf` file is present before doing so.

* Adds a systemd unit file: CentOS versions that use systemd (>= CentOS 7) will use it instead of the `init.d` script for lifecycle commands (start/stop/restart): same unit file and bash script as what's already used on debian.
  On a customer's environment with CentOS 7, using a systemd unit file has been way more reliable than relying on systemd's conversion of the `init.d` script, so let's ship it with the regular RPM pkg. 

These changes pass `dd-agent-testing`. I haven't done much manual testing but if someone feels we should I can do that.
