### PR TITLE
[Logs] Embed logs agent in dd-agent when enabled

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -178,6 +178,7 @@ end
 if linux?
   dependency 'datadog-trace-agent'
   dependency 'datadog-process-agent'
+  dependency 'datadog-logs-agent'
 end
 
 # Datadog agent

--- a/config/software/datadog-logs-agent.rb
+++ b/config/software/datadog-logs-agent.rb
@@ -1,6 +1,8 @@
 name "datadog-logs-agent"
 always_build true
 
+puts "debug tristan"
+puts ENV['INCLUDE_LOGS_AGENT']
 include_logs_agent = ENV['INCLUDE_LOGS_AGENT']
 if include_logs_agent.nil? || include_logs_agent.empty?
     include_logs_agent = false
@@ -14,12 +16,16 @@ end
 build do
   binary = "logagent"
 
+  puts include_logs_agent
   if include_logs_agent
-      if linux?
-        url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
-        command "curl #{url} -o #{binary}"
-        command "chmod +x #{binary}"
-        command "mv #{binary} #{install_dir}/bin/logs-agent"
-      end
+    puts "including the logs-agent"
+    if linux?
+      url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
+      command "curl #{url} -o #{binary}"
+      command "chmod +x #{binary}"
+      command "mv #{binary} #{install_dir}/bin/logs-agent"
+    end
+  else
+    puts "not including the logs-agent"
   end
 end 

--- a/config/software/datadog-logs-agent.rb
+++ b/config/software/datadog-logs-agent.rb
@@ -1,0 +1,25 @@
+name "datadog-logs-agent"
+always_build true
+
+include_logs_agent = ENV['INCLUDE_LOGS_AGENT']
+if include_logs_agent.nil? || include_logs_agent.empty?
+    include_logs_agent = false
+end
+
+logs_agent_version = ENV['LOGS_AGENT_VERSION']
+if logs_agent_version.nil? || logs_agent_version.empty?
+    logs_agent_version = "alpha"
+end
+
+build do
+  binary = "logagent"
+
+  if include_logs_agent
+      if linux?
+        url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
+        command "curl #{url} -o #{binary}"
+        command "chmod +x #{binary}"
+        command "mv #{binary} #{install_dir}/bin/logs-agent"
+      end
+  end
+end 


### PR DESCRIPTION
Optionally include logs-agent in dd-agent builds.

It currently supports linux only (windows should come in the following weeks).
The logs-agent currently has `nightly` and `alpha` versions.

Follow full story: https://github.com/DataDog/dd-agent/pull/3519