### PR TITLE
[Logs] Embed logs agent in dd-agent when enabled

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -178,6 +178,7 @@ end
 if linux?
   dependency 'datadog-trace-agent'
   dependency 'datadog-process-agent'
+  dependency 'datadog-logs-agent'
 end
 
 # Datadog agent

--- a/config/software/datadog-logs-agent.rb
+++ b/config/software/datadog-logs-agent.rb
@@ -1,0 +1,14 @@
+name "datadog-logs-agent"
+always_build true
+
+build do
+  binary = "logagent"
+  logs_agent_version = "alpha"
+
+  if linux?
+    url = "https://s3.amazonaws.com/public.binaries.sheepdog.datad0g.com/agent/#{logs_agent_version}/linux-amd64/#{binary}"
+    command "curl #{url} -o #{binary}"
+    command "chmod +x #{binary}"
+    command "mv #{binary} #{install_dir}/bin/logs-agent"
+  end
+end 


### PR DESCRIPTION
Include logs-agent in dd-agent builds.

It currently supports linux only (windows should come in the following weeks).

Follow full story: https://github.com/DataDog/dd-agent/pull/3520