### PR TITLE
[windows] match configuration for new generic configuration in

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -89,7 +89,7 @@ package :msi do
   bundle_theme true
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
-  extra_package_files "#{Omnibus::Config.source_dir()}\\extra_package_files"
+  extra_package_dir "#{Omnibus::Config.source_dir()}\\extra_package_files"
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -89,6 +89,7 @@ package :msi do
   bundle_theme true
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
+  extra_package_files "#{Omnibus::Config.source_dir()}\\extra_package_files"
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end

--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -66,6 +66,7 @@ package :msi do
   upgrade_code '<%= guid %>'
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
+  extra_package_files "#{Config.source_dir}\\extra_package_files"
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end

--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -66,7 +66,7 @@ package :msi do
   upgrade_code '<%= guid %>'
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
-  extra_package_files "#{Config.source_dir}\\extra_package_files"
+  extra_package_dir "#{Config.source_dir}\\extra_package_files"
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end


### PR DESCRIPTION
omnibus-ruby.

Omnibus ruby now requires that we specify the EXTRACONFS directory, rather than hard-coding.  This change matches that change (they should go in concurrently)

https://github.com/DataDog/omnibus-ruby/pull/46