### PR TITLE
[centos][prerm] Stop the agent service in prerm script

### DIFF
--- a/package-scripts/datadog-agent/prerm
+++ b/package-scripts/datadog-agent/prerm
@@ -16,7 +16,7 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
     if command -v invoke-rc.d >/dev/null 2>&1; then
         invoke-rc.d datadog-agent stop || true
 
-        # Removing the service form startup (since it's not there anymore)
+        # Removing the service from startup (since it's not there anymore)
         update-rc.d -f datadog-agent disable >/dev/null 2>&1
         update-rc.d -f datadog-agent remove
     else
@@ -25,15 +25,15 @@ if [ -f "/etc/debian_version" ] || [ "$DISTRIBUTION" = "Debian" ] || [ "$DISTRIB
 
     remove_py_compiled_files
 elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then
+    /etc/init.d/datadog-agent stop || true
+
     case "$*" in
           0)
             # We're uninstalling.
-            /etc/init.d/datadog-agent stop
-
             remove_py_compiled_files
             ;;
           1)
-            # We're upgrading. Do nothing.
+            # We're upgrading.
             # The preinst script has taken care of removing the .pyc/.pyo files
             ;;
           *)


### PR DESCRIPTION
### What this PR does

On CentOS, stop the agent service in `prerm` script.

### Motivation

Read through https://github.com/DataDog/dd-agent-omnibus/tree/master/package-scripts/datadog-agent#yum-source-httpsfedoraprojectorgwikipackagingscriptlets first :)

Right now, upgrading a CentOS Agent 5 to Agent6 doesn't stop the running agent 5 service.

The reason is that right now, the responsibility to stop the running service is on the `preinst` script, which on upgrade is executed on the new package. But when the new package changes the place where the service definition is (typically, when upgrading to Agent 6, which doesn't ship an `init.d` script anymore), the new package doesn't necessarily know how it should stop the existing agent (actually, the new package could anticipate that, see related PR on `datadog-agent`: https://github.com/DataDog/datadog-agent/pull/668).

So, generally, on upgrade, we want the "old" agent to stop its own service, because it knows how to stop itself.

That said, on upgrade, when the `prerm` of the old package is executed, the service definition file may have already been updated to the new version, so the `preinst` script of the new package still needs to try to stop the service.