### PR TITLE
Db/agent5 apm

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,7 @@ dd-agent:
   script:
     - rake agent:build-integration
   after_script:
+    - if exist pkg rd /s/q pkg
     - mkdir pkg
     - copy c:\omnibus-ruby\pkg\*.msi pkg
   artifacts:

--- a/Rakefile.rb
+++ b/Rakefile.rb
@@ -27,6 +27,7 @@ else
   PROJECT_DIR='/dd-agent-omnibus'
   FSROOT="/"
 end
+default_skip_checks=['docs']
 
 namespace :agent do
   desc 'Cleanup generated files'
@@ -83,7 +84,7 @@ namespace :agent do
     checks.each do |check|
       check.slice! "/#{ENV['INTEGRATIONS_REPO']}/"
       check.slice! "/"
-      unless skip_checks.include? check
+      unless ((skip_checks.include? check) || (default_skip_checks.include? check))
         prepare_and_execute_build(check)
         Rake::Task["agent:clean"].invoke
       end

--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -176,8 +176,10 @@ end
 if windows?
   dependency 'datadog-upgrade-helper'
 end
+
+dependency 'datadog-trace-agent'
+
 if linux?
-  dependency 'datadog-trace-agent'
   dependency 'datadog-process-agent'
 end
 

--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -1,4 +1,7 @@
+require "./lib/ostools.rb"
+
 name "datadog-trace-agent"
+
 source git: 'https://github.com/DataDog/datadog-trace-agent.git'
 
 trace_agent_branch = ENV['TRACE_AGENT_BRANCH']
@@ -14,19 +17,36 @@ end
 
 dd_agent_version = ENV['AGENT_VERSION']
 
-gourl = "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz"
-goout = "go.tar.gz"
-godir = "/usr/local/go18"
-gobin = "#{godir}/go/bin/go"
-gopath = "#{Omnibus::Config.cache_dir}/src/#{name}"
+if windows?
+  trace_agent_bin = "trace-agent.exe"
+  gourl = "https://storage.googleapis.com/golang/go1.8.1.windows-amd64.zip"
+  goout = "go.zip"
+  godir = "c:/go18"
+  gobin = "#{godir}/go/bin/go"
+  gopath = "#{Omnibus::Config.cache_dir}/src/#{name}"
 
-agent_source_dir = "#{Omnibus::Config.source_dir}/datadog-trace-agent"
-glide_cache_dir = "#{gopath}/src/github.com/Masterminds/glide"
-agent_cache_dir = "#{gopath}/src/github.com/DataDog/datadog-trace-agent"
+  agent_source_dir = "#{Omnibus::Config.source_dir}/datadog-trace-agent"
+  glide_cache_dir = "#{gopath}/src/github.com/Masterminds/glide"
+  agent_cache_dir = "#{gopath}/src/github.com/DataDog/datadog-trace-agent"
+
+
+else
+  trace_agent_bin = "trace-agent"
+  gourl = "https://storage.googleapis.com/golang/go1.8.linux-amd64.tar.gz"
+  goout = "go.tar.gz"
+  godir = "/usr/local/go18"
+  gobin = "#{godir}/go/bin/go"
+  gopath = "#{Omnibus::Config.cache_dir}/src/#{name}"
+
+  agent_source_dir = "#{Omnibus::Config.source_dir}/datadog-trace-agent"
+  glide_cache_dir = "#{gopath}/src/github.com/Masterminds/glide"
+  agent_cache_dir = "#{gopath}/src/github.com/DataDog/datadog-trace-agent"
+
+end
 
 env = {
   "GOPATH" => gopath,
-  "GOROOT" => "/usr/local/go18/go",
+  "GOROOT" => "#{godir}/go",
   "PATH" => "#{godir}/go/bin:#{ENV["PATH"]}",
   "TRACE_AGENT_VERSION" => dd_agent_version, # used by gorake.rb in the trace-agent
   "TRACE_AGENT_ADD_BUILD_VARS" => trace_agent_add_build_vars.to_s(),
@@ -38,6 +58,8 @@ build do
    # download go
    command "curl #{gourl} -o #{goout}"
    mkdir godir
+   if windows? 
+    command "7z x -o #{godir} #{goout} "
    command "tar zxfv #{goout} -C #{godir}"
 
    # Put datadog-trace-agent into a valid GOPATH
@@ -56,9 +78,9 @@ build do
    command "$GOPATH/bin/glide install", :env => env, :cwd => agent_cache_dir
    if rhel? # temporary workaround for RHEL 5 build issue with the regular `build -a` command
      command "rake install", :env => env, :cwd => agent_cache_dir
-     command "mv $GOPATH/bin/trace-agent #{install_dir}/bin/trace-agent", :env => env, :cwd => agent_cache_dir
+     command "mv $GOPATH/bin/#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
    else
      command "rake build", :env => env, :cwd => agent_cache_dir
-     command "mv ./trace-agent #{install_dir}/bin/trace-agent", :env => env, :cwd => agent_cache_dir
+     command "mv ./#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
    end
 end

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -182,6 +182,34 @@
           <RemoveFolder Id="APPLICATIONROOTDIRECTORY" On="uninstall" />
         </Component>
       </Directory>
+      <Directory Id="BIN" Name="bin">
+        <!-- Windows service declaration for APM agent -->
+          <Component Id="DATADOGAPMSERVICE" Guid="a8e611fa-aedb-4c16-969c-bb827af0bd53">
+            <File Id="trace_agent.exe"
+              Name="trace-agent.exe"
+              Vital="yes"
+              KeyPath="yes"
+              DiskId="1"
+              Source="$(var.InstallDir)/bin/trace-agent.exe"/>
+            <ServiceInstall Id="DatadogAPMServiceInstaller"
+                            DisplayName="Datadog Trace Agent"
+                            Description="Send metrics to Datadog"
+                            Name="datadog-trace-agent"
+                            ErrorControl="ignore"
+                            Start="demand"
+                            Type="ownProcess"
+                            Vital="yes"
+                            Interactive="no"
+                            Account="LocalSystem">
+                <ServiceDependency Id="datadogagent" />
+            </ServiceInstall>
+            <ServiceControl Id="DatadogAPMStartService"
+                            Name="datadog-trace-agent"
+                            Stop="both"
+                            Remove="uninstall"
+                            Wait="no" />
+        </Component>
+      </Directory>
     </DirectoryRef>
 
     <!-- Datadog Agent specific directory definitions -->
@@ -250,6 +278,7 @@
       <ComponentRef Id="checks.d" />
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="DATADOGAGENTSERVICE" />
+      <ComponentRef Id="DATADOGAPMSERVICE" />
       <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
       <ComponentRef Id="CleanupMainApplicationFolder" />
       <ComponentRef Id="RegisterConfVariables" />

--- a/resources/datadog-integrations/project.rb.erb
+++ b/resources/datadog-integrations/project.rb.erb
@@ -66,7 +66,7 @@ package :msi do
   upgrade_code '<%= guid %>'
   wix_candle_extension 'WixUtilExtension'
   wix_light_extension 'WixUtilExtension'
-  extra_package_dir "#{Config.source_dir}\\extra_package_files"
+  extra_package_dir "#{Omnibus::Config.source_dir()}\\extra_package_files"
   if ENV['SIGN_WINDOWS']
     signing_identity "ECCDAE36FDCB654D2CBAB3E8975AA55469F96E4C", machine_store: true, algorithm: "SHA256"
   end


### PR DESCRIPTION
Builds and installs the trace agent as part of the metrics agent.

Builds trace-agent.exe
signs trace-agent.exe
installs trace-agent.exe as a `demand start` service, dependent on the datadog-agent service.

Also included in this PR is repairing the individual checks package builds, which were confused by the presence of the new 'docs' directory.