### PR TITLE
Db/agent5 apm resources

### DIFF
--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -87,6 +87,9 @@ build do
    if rhel? # temporary workaround for RHEL 5 build issue with the regular `build -a` command
      command "rake install", :env => env, :cwd => agent_cache_dir
      command "mv $GOPATH/bin/#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
+   elsif windows?
+    command "rake build windres=true", :env => env, :cwd => agent_cache_dir
+    command "mv ./#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
    else
      command "rake build", :env => env, :cwd => agent_cache_dir
      command "mv ./#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -220,6 +220,12 @@
                             Stop="both"
                             Remove="uninstall"
                             Wait="no" />
+            <!-- The "Name" field must match the argument to eventlog.Open() -->
+            <util:EventSource Log="Application" Name="datadog-trace-agent"
+                  EventMessageFile="[BIN]trace-agent.exe"
+                  SupportsErrors="yes"
+                  SupportsInformationals="yes"
+                  SupportsWarnings="yes"/>
         </Component>
       </Directory>
     </DirectoryRef>


### PR DESCRIPTION
Adds in call to build with event log message file and windows resources.

First change is to change build command to `"rake build windres=true"`.  Windres=true tells the trace agent to build with windows resources (it doesn't by default in case that part of the toolchain isn't present, for instance when cross-compiling on linux).

Second change in the install script registers the trace agent binary as the `log source` for event viewer; tells event viewer where to get the log strings from.