### PR TITLE
failure to get process agent will make the build fail

### DIFF
--- a/config/software/datadog-process-agent.rb
+++ b/config/software/datadog-process-agent.rb
@@ -12,7 +12,8 @@ build do
   # FIXME (conor): Add ship_license once repo is open source
   binary = "process-agent-amd64-#{version}"
   url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-  command "curl #{url} -o #{binary}"
+  # -f will make the failure noisy
+  command "curl -f #{url} -o #{binary}"
   command "chmod +x #{binary}"
   command "mv #{binary} #{install_dir}/bin/process-agent"
-end 
+end


### PR DESCRIPTION
Currently, if we fail to grab the process agent, it won't fail. Curl doesn't error out if you get a 4xx or 5xx response code. However, it will if you pass it the option `-f`. This will make it fail noisily. 