### PR TITLE
[integrations] Update manifest validation for 0.1.1

### DIFF
--- a/resources/datadog-integrations/validate_manifest.rb
+++ b/resources/datadog-integrations/validate_manifest.rb
@@ -21,6 +21,22 @@ def validate_manifest_0_1_0(manifest_hash)
   validate_manifest_loop(manifest_hash, mandatory_fields)
 end
 
+def validate_manifest_0_1_1(manifest_hash)
+  mandatory_fields = [
+    "maintainer",
+    "manifest_version",
+    "max_agent_version",
+    "min_agent_version",
+    "name",
+    "short_description",
+    "support",
+    "type",
+    "version",
+    "guid",
+  ]
+  validate_manifest_loop(manifest_hash, mandatory_fields)
+end
+
 def validate_manifest_1_0_0(manifest_hash)
   mandatory_fields = [
     "maintainer",


### PR DESCRIPTION
## What this PR does

Updates manifest validation method for `0.1.1` manifest version. We now use that version in integrations-core but it wasn't added here.

## Motivation

The manifest in integrations-core have been updated in https://github.com/DataDog/integrations-core/pull/857 (bump to `0.1.1`, new field: `type`)

Since then the CI on `dd-agent-omnibus` was failing. Also the single integration build would have been broken too since we use the manifest validation there.

## Questions

We don't necessarily have to answer them all now but we should at some point :)

1. Is `type` indeed a mandatory field for the `0.1.1` manifests?
2. Are there up-to-date docs on the manifest format/fields? (all I could find was this: https://docs.datadoghq.com/guides/integration_sdk/#manifest-json but it's not fully up-to-date)
3. https://github.com/DataDog/dd-agent-omnibus/pull/152 adds a validator for a `1.0.0` manifest, do we use that version anywhere, and have we decided on a final format for that manifest version?
4. any reason not to validate the manifests in the main agent build? (i.e. in https://github.com/DataDog/dd-agent-omnibus/blob/master/config/software/datadog-agent-integrations.rb)

cc @l0k0ms @hush-hush @gmmeyer 