### PR TITLE
datadog user should not be a system user

### DIFF
--- a/package-scripts/datadog-agent/posttrans
+++ b/package-scripts/datadog-agent/posttrans
@@ -7,7 +7,8 @@
 getent group dd-agent >/dev/null || groupadd -r dd-agent
 getent passwd dd-agent >/dev/null || \
     useradd -r -M -g dd-agent -d /usr/share/datadog/agent -s /bin/sh \
-    -c "Datadog Agent" dd-agent
+    -c "Datadog Agent" dd-agent && \
+    usermod -L dd-agent
 
 # See comment in postinst script for an explanation of the logic below
 /etc/init.d/datadog-agent configcheck > /dev/null 2>&1

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -51,7 +51,8 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
     getent group dd-agent >/dev/null || groupadd -r dd-agent
     getent passwd dd-agent >/dev/null || \
       useradd -r -M -g dd-agent -d $INSTALL_DIR -s /bin/sh \
-        -c "Datadog Agent" dd-agent
+        -c "Datadog Agent" dd-agent && \
+        usermod -L dd-agent
     # Stop the old agent before installing
     if [ -f "/etc/init.d/datadog-agent" ]; then
       /etc/init.d/datadog-agent stop || true


### PR DESCRIPTION
This PR mirrors the work done on the Datadog Agent in this Pull Request:

https://github.com/DataDog/datadog-agent/pull/892

It makes our system user compliant with CIS 5.4.2.