### PR TITLE
agent5: add a dependency on prometheus-client

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -47,6 +47,7 @@ dependency 'simplejson'
 dependency 'tornado'
 dependency 'uptime'
 dependency 'uuid'
+dependency 'prometheus-client'
 
 # Check dependencies
 # psutil is required by the core agent on Windows


### PR DESCRIPTION
Add a dependency on the prometheus-client provided [here](https://github.com/DataDog/omnibus-software/pull/172).