### PR TITLE
[Windows] Add process agent support to agent5.

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -186,7 +186,7 @@ end
 
 dependency 'datadog-trace-agent'
 
-if linux?
+if not osx?
   dependency 'datadog-process-agent'
 end
 

--- a/config/software/datadog-process-agent.rb
+++ b/config/software/datadog-process-agent.rb
@@ -1,5 +1,6 @@
 name "datadog-process-agent"
 always_build true
+require "./lib/ostools.rb"
 
 process_agent_branch = ENV['PROCESS_AGENT_BRANCH']
 if process_agent_branch.nil? || process_agent_branch.empty?
@@ -7,13 +8,21 @@ if process_agent_branch.nil? || process_agent_branch.empty?
 end
 default_version process_agent_branch
 
-
 build do
-  # FIXME (conor): Add ship_license once repo is open source
-  binary = "process-agent-amd64-#{version}"
-  url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
-  # -f will make the failure noisy
-  command "curl -f #{url} -o #{binary}"
-  command "chmod +x #{binary}"
-  command "mv #{binary} #{install_dir}/bin/process-agent"
+  if windows?
+    binary = "process-agent-windows-#{version}.exe"
+    target_binary = "process-agent.exe"
+    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
+    curl_command = "powershell -Command wget -OutFile #{binary} #{url}"
+    command curl_command
+    command "mv #{binary} #{install_dir}/bin/#{target_binary}"
+  else
+    binary = "process-agent-amd64-#{version}"
+    target_binary = "process-agent"
+    url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
+    curl_command = "curl -f #{url} -o #{binary}"
+    command curl_command
+    command "chmod +x #{binary}"
+    command "mv #{binary} #{install_dir}/bin/#{target_binary}"
+  end
 end

--- a/resources/datadog-agent/msi/localization-en-us.wxl.erb
+++ b/resources/datadog-agent/msi/localization-en-us.wxl.erb
@@ -1,8 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <WixLocalization Culture="en-us" xmlns="http://schemas.microsoft.com/wix/2006/localization">
   <String Id="LANG">1033</String>
-  <String Id="ProductName"><%= friendly_name %></String>
-  <String Id="ManufacturerName"><%= maintainer %></String>
+  <String Id="ProductName" Overridable="no" Localizable="no">Datadog Agent</String>
+  <String Id="ManufacturerName" Overridable="no" Localizable="no">Datadog, Inc.</String>
+  <String Id="CompanyName" Overridable="no" Localizable="no">Datadog, Inc.</String>
+  <String Id="CompanyNameShort" Overridable="no" Localizable="no">Datadog</String>
+  <String Id="InstallerComment">Copyright 2018 [CompanyName]</String>
+  
   <String Id="WelcomeDlgTitle">{\WixUI_Font_Bigger}Welcome to the [ProductName] Setup Wizard</String>
 
   <String Id="LicenseAgreementDlgTitle">{\WixUI_Font_Title_White}End-User License Agreement</String>
@@ -62,5 +66,16 @@
   <String Id="FailureCloseButton">&amp;Close</String>
   <String Id="WillInstall">[WixBundleName] will be installed on your device</String>
   <String Id="InstallLicenseLinkText">By installing you accept these &lt;a href="#"&gt;license terms&lt;/a&gt;</String>
+
+  <!-- these strings are for the main agent service install -->
+  <String Id="ServiceDisplayName">[ProductName]</String>
+  <String Id="ServiceDescription">Send metrics to [ShortCompanyName]</String>
+  <!-- these strings are for the apm agent service install -->
+  <String Id="ServiceApmDisplayName">[ShortCompanyName] Trace Agent</String>
+  <String Id="ServiceApmDescription">Send tracing metrics to [ShortCompanyName]</String>
+
+  <!-- these strings are for the process agent service install -->
+  <String Id="ServiceProcessDisplayName">[ShortCompanyName] Process Agent</String>
+  <String Id="ServiceProcessDescription">Send process metrics to [ShortCompanyName]</String>
 
 </WixLocalization>

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -9,7 +9,7 @@
     Name is made of localized product name and version number.
   -->
   <Product Id="*"
-           Name="Datadog Agent"
+           Name="!(loc.ProductName)"
            Language="1033"
            Version="$(var.VersionNumber)"
            Manufacturer="!(loc.ManufacturerName)"
@@ -21,14 +21,14 @@
       The install should be done for the whole machine not just the current user
     -->
     <Package Id="*"
-             Keywords="Installer"
-             Comments="Copyright 2015 Datadog, Inc."
-             Description="Datadog Agent v$(var.DisplayVersionNumber)"
-             Manufacturer="!(loc.ManufacturerName)"
-             InstallScope="perMachine"
-             InstallerVersion="400"
-             Languages="1033"
-             InstallPrivileges="elevated"
+            Keywords="Installer"
+            Comments="!(loc.InstallerComment)"
+            Description="!(loc.ProductName) $(var.DisplayVersionNumber)"
+            Manufacturer="!(loc.ManufacturerName)"
+            InstallScope="perMachine"
+            InstallerVersion="400"
+            Languages="1033"
+            InstallPrivileges="elevated"
              Compressed="yes" />
 
     <!-- This removes entirely the previous version -->
@@ -174,16 +174,22 @@
                 DiskId="1"
                 Source="$(var.DistFiles)/ddagent.exe"/>
           <ServiceInstall Id="DatadogServiceInstaller"
-                          DisplayName="Datadog Agent"
-                          Description="Send metrics to Datadog"
-                          Name="DatadogAgent"
-                          ErrorControl="ignore"
-                          Start="auto"
-                          Type="ownProcess"
-                          Vital="yes"
-                          Interactive="no"
+                            DisplayName="!(loc.ServiceDisplayName)"
+                            Description="!(loc.ServiceDescription)"
+                            Name="DatadogAgent"
+                            ErrorControl="ignore"
+                            Start="auto"
+                            Type="ownProcess"
+                            Vital="yes"
+                            Interactive="no"
                           Account="LocalSystem">
-              <ServiceDependency Id="winmgmt" />
+            <util:ServiceConfig
+                FirstFailureActionType='restart'
+                SecondFailureActionType='restart'
+                ThirdFailureActionType='restart'            
+                RestartServiceDelayInSeconds='30'
+                ResetPeriodInDays='1'/>
+            <ServiceDependency Id="winmgmt" />
           </ServiceInstall>
           <ServiceControl Id="DatadogStartService"
                           Name="DatadogAgent"
@@ -204,16 +210,22 @@
               DiskId="1"
               Source="$(var.InstallDir)/bin/trace-agent.exe"/>
             <ServiceInstall Id="DatadogAPMServiceInstaller"
-                            DisplayName="Datadog Trace Agent"
-                            Description="Send metrics to Datadog"
+                            DisplayName="!(loc.ServiceApmDisplayName)"
+                            Description="!(loc.ServiceApmDescription)"
                             Name="datadog-trace-agent"
                             ErrorControl="ignore"
-                            Start="demand"
+                            Start="auto"
                             Type="ownProcess"
                             Vital="yes"
                             Interactive="no"
                             Account="LocalSystem">
-                <ServiceDependency Id="datadogagent" />
+              <util:ServiceConfig
+                FirstFailureActionType='restart'
+                SecondFailureActionType='restart'
+                ThirdFailureActionType='restart'            
+                RestartServiceDelayInSeconds='30'
+                ResetPeriodInDays='1'/>
+              <ServiceDependency Id="datadogagent" />
             </ServiceInstall>
             <ServiceControl Id="DatadogAPMStartService"
                             Name="datadog-trace-agent"
@@ -227,6 +239,44 @@
                   SupportsInformationals="yes"
                   SupportsWarnings="yes"/>
         </Component>
+        <!-- Windows service declaration for Process agent -->
+          <Component Id="DATADOGPROCESSSERVICE" Guid="3b119795-ddf8-44eb-9d53-301f7186e2f3">
+            <File Id="process_agent.exe"
+                Name="process-agent.exe"
+                Vital="yes"
+                KeyPath="yes"
+                DiskId="1"
+                Source="$(var.InstallDir)/bin/process-agent.exe"/>
+            <ServiceInstall Id="DatadogProcessServiceInstaller"
+                            DisplayName="!(loc.ServiceProcessDisplayName)"
+                            Description="!(loc.ServiceProcessDescription)"
+                            Name="datadog-process-agent"
+                            ErrorControl="ignore"
+                            Start="auto"
+                            Type="ownProcess"
+                            Vital="yes"
+                            Interactive="no"
+                            Account="LocalSystem">
+              <util:ServiceConfig
+                FirstFailureActionType='restart'
+                SecondFailureActionType='restart'
+                ThirdFailureActionType='restart'            
+                RestartServiceDelayInSeconds='30'
+                ResetPeriodInDays='1'/>
+              <ServiceDependency Id="datadogagent" />
+            </ServiceInstall>
+            <ServiceControl Id="DatadogProcessStartService"
+                            Name="datadog-process-agent"
+                            Stop="both"
+                            Remove="uninstall"
+                            Wait="no" />
+            <!-- The "Name" field must match the argument to eventlog.Open() -->
+            <util:EventSource Log="Application" Name="datadog-process-agent"
+                    EventMessageFile="[AGENT]process-agent.exe"
+                    SupportsErrors="yes"
+                    SupportsInformationals="yes"
+                    SupportsWarnings="yes"/>
+          </Component>
       </Directory>
     </DirectoryRef>
 
@@ -303,6 +353,7 @@
       <ComponentRef Id="ApplicationShortcut" />
       <ComponentRef Id="DATADOGAGENTSERVICE" />
       <ComponentRef Id="DATADOGAPMSERVICE" />
+      <ComponentRef Id="DATADOGPROCESSSERVICE" />
       <ComponentGroupRef Id="ExtraEXAMPLECONFSLOCATION" />
       <ComponentRef Id="CleanupMainApplicationFolder" />
       <ComponentRef Id="RegisterConfVariables" />

--- a/resources/datadog-integrations/msi/source.wxs.erb
+++ b/resources/datadog-integrations/msi/source.wxs.erb
@@ -114,6 +114,8 @@
     <Property Id="ARPHELPLINK" Value="https://datadoghq.com/" />
     <Property Id="WIXUI_INSTALLDIR" Value="<%= wix_install_dir %>" />
 
+    <Property Id="ShortCompanyName" Value="!(loc.CompanyNameShort)" />
+    
     <UIRef Id="ProjectUI_InstallDir"/>
     <UI Id="ProjectUI_InstallDir">
       <UIRef Id="WixUI_Minimal"/>


### PR DESCRIPTION
Install both APM and PRocess as an automatic start service (instead of
manual start).  Relies on the services self-stopping if they're so
configured.

Change all services to automatic restart on failure.

Move service names, descriptions, etc. into the localization file

Companion PR https://github.com/DataDog/dd-agent/pull/3655