### PR TITLE
[unix] Remove /opt/datadog-agent/agent/checks.d directory

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -32,9 +32,6 @@ python_lib_path = File.join(install_dir, "embedded", "lib", "python2.7", "site-p
 whitelist_file "#{python_lib_path}"
 
 build do
-  # Agent code
-  mkdir  "#{install_dir}/agent/checks.d"
-
   checks = []
 
   # build do cannot have fully dynamic actions in it

--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -28,9 +28,6 @@ build do
   mkdir  "#{install_dir}/agent/"
 
   # Agent code
-  mkdir "#{install_dir}/agent/checks.d"
-  copy 'checks.d', "#{install_dir}/agent/"
-
   copy 'checks', "#{install_dir}/agent/"
   copy 'dogstream', "#{install_dir}/agent/"
   copy 'utils', "#{install_dir}/agent/"


### PR DESCRIPTION
We're not shipping anything in it anymore (wheel-based build), let's
remove it to avoid confusion.