### PR TITLE
[windows] Set services to start on install; they'll stop if not

### DIFF
--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -229,6 +229,7 @@
             </ServiceInstall>
             <ServiceControl Id="DatadogAPMStartService"
                             Name="datadog-trace-agent"
+                            Start="install"
                             Stop="both"
                             Remove="uninstall"
                             Wait="no" />
@@ -267,6 +268,7 @@
             </ServiceInstall>
             <ServiceControl Id="DatadogProcessStartService"
                             Name="datadog-process-agent"
+                            Start="install"
                             Stop="both"
                             Remove="uninstall"
                             Wait="no" />


### PR DESCRIPTION
configured.  Failing to do this, however, will prevent the services from
starting on startup or upgrade even when they're preconfigured.