### PR TITLE
[deb] Stop adding new key

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -117,8 +117,6 @@ elsif debian?
   replace 'datadog-agent-base (<< 5.0.0)'
   replace 'datadog-agent-lib (<< 5.0.0)'
   conflict 'datadog-agent-base (<< 5.0.0)'
-  # needed starting debian 9
-  runtime_dependency 'gnupg'
 end
 
 # ------------------------------------

--- a/package-scripts/datadog-agent/preinst
+++ b/package-scripts/datadog-agent/preinst
@@ -33,18 +33,6 @@ if [ "$DISTRIBUTION" != "Darwin" ]; then
         rm /etc/dd-agent/supervisor_ddagent.conf
     fi
 
-    # Prepare the GPG keys rotation:
-    # Add the new one to the list of trusted APT keys.
-    # Some servers are on severely restricted networks.
-    # Check if key already exists.
-    echo "Prepare Datadog Agent keys rotation"
-    echo -n "  Add the new 'Datadog, Inc <package@datadoghq.com>' key to the list of APT trusted keys."
-    if $( apt-key finger | grep -q 'A292 3DFF 56ED A6E7 6E55  E492 D3A8 0E30 382E 94DE' ); then
-        echo "... key already installed"
-    else
-        apt-key adv --recv-keys --keyserver hkp://keyserver.ubuntu.com:80 382E94DE >/dev/null 2>&1 && echo " ... OK" \
-            ||  printf " ... failed\nWARNING: If you are running Debian 9, the \"dirmngr\" package is needed to install the new APT key required by future versions of the Agent.\nIf this package is not installed, please install it and then re-install the agent. The agent installation may break in the future if the new APT key is not installed on your system\n"
-    fi
     #DEBHELPER#
 
   elif [ -f "/etc/redhat-release" ] || [ -f "/etc/system-release" ] || [ -f "/etc/SuSE-release" ] || [ "$DISTRIBUTION" = "RedHat" ] || [ "$DISTRIBUTION" = "CentOS" ] || [ "$DISTRIBUTION" = "openSUSE" ] || [ "$DISTRIBUTION" = "Amazon" ] || [ "$DISTRIBUTION" = "SUSE" ] || [ "$DISTRIBUTION" = "Arista" ]; then


### PR DESCRIPTION
The new key is now used to sign the repo. No point in adding it in the
preinst script since a user won't be able to download the package
if the key's not already trusted on the system.

Also, remove dep on `gnupg` that came from the `apt-key` usage in
preinst script.