### PR TITLE
Add cacerts as an explicit dependency.  Cacerts is a dependency of some

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -29,6 +29,7 @@ end
 
 # Agent dependencies
 dependency 'boto'
+dependency 'cacerts'
 dependency 'docker-py'
 
 dependency 'jmxfetch'


### PR DESCRIPTION
of the other packages, but the file is required.  Will prevent this from
being inadvertently removed (and will cause it to be installed on
windows, which it's currently missing)