### PR TITLE
Remove PYC files after datadog-agent-integrations

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -140,5 +140,9 @@ build do
         pip "install -c #{install_dir}/agent_requirements.txt *.whl", :env => build_env, :cwd => "#{project_dir}/#{check}"
       end
     end
+    if windows?
+        command "CHDIR #{install_dir} & del /Q /S *.pyc"
+        command "CHDIR #{install_dir} & del /Q /S *.chm"
+    end
   end
 end


### PR DESCRIPTION
Previous releases the PYCs were pruned in the agent definition; however, the integrations definition comes after that, and with the new wheels installation leaves a lot of PYCs around.