### PR TITLE
[trace-agent] we should be fine to pass the default_version to Makefile

### DIFF
--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -16,8 +16,6 @@ if ENV.has_key?('TRACE_AGENT_ADD_BUILD_VARS') && ENV['TRACE_AGENT_ADD_BUILD_VARS
   trace_agent_add_build_vars = false
 end
 
-dd_agent_version = ENV['AGENT_VERSION']
-
 
 if windows?
   trace_agent_bin = "trace-agent.exe"
@@ -49,7 +47,7 @@ env = {
   "GOPATH" => gopath,
   "GOROOT" => "#{godir}/go",
   "PATH" => "#{godir}/go/bin:#{ENV["PATH"]}",
-  "TRACE_AGENT_VERSION" => dd_agent_version, # used by 'make' in the trace-agent
+  "TRACE_AGENT_VERSION" => version, # used by 'make' in the trace-agent
   "TRACE_AGENT_ADD_BUILD_VARS" => trace_agent_add_build_vars.to_s(),
 }
 


### PR DESCRIPTION
This was going to be prone to set an incorrect version for the trace-agent when building on windows. Let's use `version` instead and let Makefile handle setting the default `0.99.0` for nightlies/untagged versions. 

Sister PR: https://github.com/DataDog/datadog-trace-agent/pull/409