### PR TITLE
Clean up integration core deps and yaml files

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -73,7 +73,7 @@ build do
     # loop through checks and install each without their dependencies
     # we rely on a static Agent environment that was built above. 
     checks.each do |check|
-      if blacklist.include? check:
+      if blacklist.include?(check):
         next
 
       # Only use the parts of the filename we need

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -26,6 +26,7 @@ end
 
 blacklist = [
   'datadog_checks_base',  # namespacing package for wheels (NOT AN INTEGRATION)
+  'datadog_checks_dev',   # developer tooling for working on integrations (NOT AN INTEGRATION)
 ]
 
 python_lib_path = File.join(install_dir, "embedded", "lib", "python2.7", "site-packages")
@@ -111,18 +112,18 @@ build do
       end
 
       # Copy the check config to the conf directories
-      if File.exists? "#{project_dir}/#{check}/conf.yaml.example"
-        copy "#{project_dir}/#{check}/conf.yaml.example", "#{conf_directory}/#{check}.yaml.example"
+      if File.exists? "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.example"
+        copy "#{project_dir}/#{check}/data/conf.yaml.example", "#{conf_directory}/#{check}.yaml.example"
       end
       # Copy the default config, if it exists
-      if File.exists? "#{project_dir}/#{check}/conf.yaml.default"
-        copy "#{project_dir}/#{check}/conf.yaml.default", "#{conf_directory}/#{check}.yaml.default"
+      if File.exists? "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.default"
+        copy "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.default", "#{conf_directory}/#{check}.yaml.default"
       end
 
       # We don't have auto_conf on windows yet
       unless windows?
-        if File.exists? "#{project_dir}/#{check}/auto_conf.yaml"
-          copy "#{project_dir}/#{check}/auto_conf.yaml", "#{conf_directory}/auto_conf/#{check}.yaml"
+        if File.exists? "#{project_dir}/#{check}/datadog_checks/#{check}/data/auto_conf.yaml"
+          copy "#{project_dir}/#{check}/datadog_checks/#{check}/data/auto_conf.yaml", "#{conf_directory}/auto_conf/#{check}.yaml"
         end
       end
 

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -91,7 +91,7 @@ build do
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
       # Uninstall pip
-      freeze_file = File.read("#{windows_safe_path(project_dir)}\\agent_requirements.txt")
+      freeze_file = File.read("#{windows_safe_path(install_dir)}\\agent_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
           pip "uninstall -y #{dep}"
@@ -108,7 +108,7 @@ build do
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      freeze_file = File.read("#{project_dir}/agent_requirements.txt")
+      freeze_file = File.read("#{install_dir}/agent_requirements.txt")
       UNINSTALL_PIPTOOLS_DEPS.each do |dep|
         if not freeze_file.include? dep
            pip "uninstall -y #{dep}"

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -90,13 +90,9 @@ build do
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
       command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
 
-      # Uninstall pip
-      freeze_file = File.read("#{windows_safe_path(install_dir)}\\agent_requirements.txt")
-      UNINSTALL_PIPTOOLS_DEPS.each do |dep|
-        if not freeze_file.include? dep
-          pip "uninstall -y #{dep}"
-        end
-      end
+      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        command("#{python_pip_uninstall} #{dep}")
 
       command("#{python_bin} -m #{python_pip_reqs} #{windows_safe_path(project_dir)}\\static_requirements.txt")
     else
@@ -108,12 +104,8 @@ build do
       command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
-      freeze_file = File.read("#{install_dir}/agent_requirements.txt")
-      UNINSTALL_PIPTOOLS_DEPS.each do |dep|
-        if not freeze_file.include? dep
-           pip "uninstall -y #{dep}"
-        end
-      end
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        pip "uninstall -y #{dep}"
       
       pip "install -c #{install_dir}/agent_requirements.txt --require-hashes -r #{project_dir}/static_requirements.txt"
     end

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -56,6 +56,9 @@ build do
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
     python_pip_reqs = "pip install --require-hashes -r #{windows_safe_path(project_dir)}"
+
+    # Need to keep the environment markers from the .in file so we will compile this here
+    # since the compiled .txt file will only have platform specific deps
     python_pip_compile = "pip-compile #{windows_safe_path(project_dir)}"
 
     # Install the static environment requirements that the Agent and all checks will use

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -72,7 +72,7 @@ build do
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir}\\datadog_checks_base\\requirements.in")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\requirements.in")
       command("#{python_bin} -m #{python_pip_reqs}\\static_requirements.txt")
     else
       build_env = {

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -80,7 +80,7 @@ build do
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      command("python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/requirements.in")
+      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/requirements.in")
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
     

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -72,7 +72,7 @@ build do
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\requirements.in")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\agent_requirements.in")
       command("#{python_bin} -m #{python_pip_reqs}\\static_requirements.txt")
     else
       build_env = {
@@ -80,7 +80,7 @@ build do
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/requirements.in")
+      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/agent_requirements.in")
       pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
     
@@ -112,7 +112,7 @@ build do
 
       # Copy the check config to the conf directories
       if File.exists? "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.example"
-        copy "#{project_dir}/#{check}/data/conf.yaml.example", "#{conf_directory}/#{check}.yaml.example"
+        copy "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.example", "#{conf_directory}/#{check}.yaml.example"
       end
       # Copy the default config, if it exists
       if File.exists? "#{project_dir}/#{check}/datadog_checks/#{check}/data/conf.yaml.default"

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -92,7 +92,7 @@ build do
 
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
-        command("#{python_pip_uninstall} #{dep}")
+        command("#{python_bin} -m #{python_pip_uninstall} #{dep}")
       end
 
       command("#{python_bin} -m #{python_pip_reqs} #{windows_safe_path(project_dir)}\\static_requirements.txt")

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -52,6 +52,17 @@ build do
       conf_directory = "../../extra_package_files/EXAMPLECONFSLOCATION"
     end
 
+  # Install all the requirements
+  if windows?
+    pip "install pip-tools==2.0.2"
+  else
+    build_env = {
+      "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
+      "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
+    }
+    pip "install pip-tools==2.0.2", :env => build_env
+  end
+
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
@@ -72,8 +83,8 @@ build do
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      pip "compile #{windows_safe_path(project_dir)}/agent_requirements.txt"
-      pip "install --require-hashes -r #{project_dir}/agent_requirements.txt"
+      command("pip-compile #{project_dir}/agent_requirements.txt > static_requirements.txt")
+      pip "install --require-hashes -r #{project_dir}/static_requirements.txt"
     end
     
     # loop through checks and install each without their dependencies

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -64,7 +64,7 @@ build do
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{pip_compile}\\datadog_checks_base\\requirements.in > #{windows_safe_path(project_dir)}\\agent_requirements.txt"
+      command("#{python_pip_compile}\\datadog_checks_base\\requirements.in > #{windows_safe_path(project_dir)}\\agent_requirements.txt"
       command("#{python_bin} -m #{python_pip_reqs}\\agent_requirements.txt")
     else
       build_env = {

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -63,6 +63,9 @@ build do
         " --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8"
     all_reqs_file.close
 
+    # Set frozen requirements
+    pip "freeze > #{install_dir}/agent_requirements.txt"
+
     # Install all the requirements
     if windows?
       pip "install pip-tools==#{PIPTOOLS_VERSION}"
@@ -75,9 +78,6 @@ build do
       pip "install pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
       pip "install -r #{project_dir}/check_requirements.txt", :env => build_env
     end
-
-    # Set frozen requirements
-    pip "freeze > #{install_dir}/agent_requirements.txt"
 
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -56,18 +56,21 @@ build do
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
     python_pip_reqs = "pip install --require-hashes -r #{windows_safe_path(project_dir)}"
+    python_pip_compile = "pip-compile #{windows_safe_path(project_dir)}"
 
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m #{python_pip_reqs}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.txt")
+      command("#{pip_compile}\\datadog_checks_base\\requirements.in > #{windows_safe_path(project_dir)}\\agent_requirements.txt"
+      command("#{python_bin} -m #{python_pip_reqs}\\agent_requirements.txt")
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      pip "install --require-hashes -r #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.txt"
+      pip "compile #{windows_safe_path(project_dir)}/agent_requirements.txt"
+      pip "install --require-hashes -r #{project_dir}/agent_requirements.txt"
     end
     
     # loop through checks and install each without their dependencies

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -93,6 +93,7 @@ build do
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
         command("#{python_pip_uninstall} #{dep}")
+      end
 
       command("#{python_bin} -m #{python_pip_reqs} #{windows_safe_path(project_dir)}\\static_requirements.txt")
     else
@@ -106,6 +107,7 @@ build do
       # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
       for dep in UNINSTALL_PIPTOOLS_DEPS
         pip "uninstall -y #{dep}"
+      end
       
       pip "install -c #{install_dir}/agent_requirements.txt --require-hashes -r #{project_dir}/static_requirements.txt"
     end

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -64,7 +64,7 @@ build do
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_pip_compile}\\datadog_checks_base\\requirements.in > #{windows_safe_path(project_dir)}\\agent_requirements.txt"
+      command("#{python_pip_compile}\\datadog_checks_base\\requirements.in > #{windows_safe_path(project_dir)}\\agent_requirements.txt")
       command("#{python_bin} -m #{python_pip_reqs}\\agent_requirements.txt")
     else
       build_env = {

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -9,6 +9,7 @@ relative_path 'integrations-core'
 
 PIPTOOLS_VERSION = "2.0.2"
 WHEELS_VERSION = "0.30.0"
+UNINSTALL_PIPTOOLS_DEPS = ['first', 'click', 'pip-tools']
 
 # The only integrations that will be packaged with the agent
 # are the ones that are officiallly supported.
@@ -60,34 +61,40 @@ build do
     # FIX THIS these dependencies have to be grabbed from somewhere
     all_reqs_file.puts "wheel==#{WHEELS_VERSION} --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"\
         " --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8"
-    all_reqs_file.puts "pip-tools==#{PIPTOOLS_VERSION} --hash=sha256:90bbe6731a6a34d339bf14d90cf2892475386c7d06c458208191ac9992110e0a"
     all_reqs_file.close
 
     # Install all the requirements
     if windows?
+      pip "install pip-tools==#{PIPTOOLS_VERSION}"
       pip "install -r #{project_dir}/check_requirements.txt"
     else
       build_env = {
         "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
+      pip "install pip-tools==#{PIPTOOLS_VERSION}", :env => build_env
       pip "install -r #{project_dir}/check_requirements.txt", :env => build_env
     end
 
     # Set frozen requirements
     pip "freeze > #{install_dir}/agent_requirements.txt"
 
-
     # Windows pip workaround to support globs
     python_bin = "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\""
     python_pip_no_deps = "pip install --no-deps #{windows_safe_path(project_dir)}"
     python_pip_reqs = "pip install -c #{windows_safe_path(install_dir)}\\agent_requirements.txt --require-hashes -r #{windows_safe_path(project_dir)}"
-
+    python_pip_uninstall = "pip uninstall -y"
 
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\agent_requirements.in")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir)}\\datadog_checks_base\\datadog_checks\\data\\agent_requirements.in")
+
+      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        command("#{python_bin} -m #{python_pip_uninstall} #{dep}")
+      end
+
       command("#{python_bin} -m #{python_pip_reqs}\\static_requirements.txt")
     else
       build_env = {
@@ -95,10 +102,16 @@ build do
         "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
       }
       pip "install --no-deps .", :env => build_env, :cwd => "#{project_dir}/datadog_checks_base"
-      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/agent_requirements.in")
+      command("#{install_dir}/embedded/bin/python -m piptools compile --generate-hashes --output-file #{project_dir}/static_requirements.txt #{project_dir}/datadog_checks_base/datadog_checks/data/agent_requirements.in")
+
+      # Uninstall the deps that pip-compile installs so we don't include them in the final artifact
+      for dep in UNINSTALL_PIPTOOLS_DEPS
+        pip "uninstall -y #{dep}"
+      end
+      
       pip "install -c #{install_dir}/agent_requirements.txt --require-hashes -r #{project_dir}/static_requirements.txt"
     end
-    
+
     # loop through checks and install each without their dependencies
     # we rely on a static Agent environment that was built above. 
     checks.each do |check|

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -73,8 +73,7 @@ build do
     # loop through checks and install each without their dependencies
     # we rely on a static Agent environment that was built above. 
     checks.each do |check|
-      if blacklist.include?(check):
-        next
+      next if blacklist.include?(check)
 
       # Only use the parts of the filename we need
       check.slice! "#{project_dir}/"

--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -72,7 +72,7 @@ build do
     # Install the static environment requirements that the Agent and all checks will use
     if windows?
       command("#{python_bin} -m #{python_pip_no_deps}\\datadog_checks_base")
-      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir})\\datadog_checks_base\\requirements.in")
+      command("#{python_bin} -m piptools compile --generate-hashes --output-file #{windows_safe_path(project_dir)}\\static_requirements.txt #{windows_safe_path(project_dir}\\datadog_checks_base\\requirements.in")
       command("#{python_bin} -m #{python_pip_reqs}\\static_requirements.txt")
     else
       build_env = {

--- a/release.json
+++ b/release.json
@@ -9,6 +9,17 @@
 		"PROCESS_AGENT_BRANCH": "master",
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
+	}, 
+	"5.25.0-testnickdeps": {
+		"AGENT_VERSION": "5.26.0",
+		"AGENT_BRANCH": "master",
+		"AGENT6_BRANCH": "master",
+		"INTEGRATIONS_CORE_BRANCH": "master",
+		"TRACE_AGENT_BRANCH": "master",
+		"TRACE_AGENT_ADD_BUILD_VARS": "true",
+		"PROCESS_AGENT_BRANCH": "master",
+		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
+		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},
 	"5.25.0": {
 		"AGENT_VERSION": "5.25.0",

--- a/release.json
+++ b/release.json
@@ -9,7 +9,7 @@
 		"PROCESS_AGENT_BRANCH": "master",
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
-	}, 
+	},
 	"5.25.0": {
 		"AGENT_VERSION": "5.25.0",
 		"AGENT_BRANCH": "5.25.0",

--- a/release.json
+++ b/release.json
@@ -10,6 +10,17 @@
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},
+	"5.25.0-testnickdeps": {
+		"AGENT_VERSION": "5.26.0",
+		"AGENT_BRANCH": "master",
+		"AGENT6_BRANCH": "master",
+		"INTEGRATIONS_CORE_BRANCH": "master",
+		"TRACE_AGENT_BRANCH": "master",
+		"TRACE_AGENT_ADD_BUILD_VARS": "true",
+		"PROCESS_AGENT_BRANCH": "master",
+		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
+		"OMNIBUS_SOFTWARE_BRANCH": "master"
+	},
 	"5.25.0": {
 		"AGENT_VERSION": "5.25.0",
 		"AGENT_BRANCH": "5.25.0",

--- a/release.json
+++ b/release.json
@@ -15,9 +15,9 @@
 		"AGENT_BRANCH": "master",
 		"AGENT6_BRANCH": "master",
 		"INTEGRATIONS_CORE_BRANCH": "master",
-		"TRACE_AGENT_BRANCH": "master",
+		"TRACE_AGENT_BRANCH": "6.3.0",
 		"TRACE_AGENT_ADD_BUILD_VARS": "true",
-		"PROCESS_AGENT_BRANCH": "master",
+		"PROCESS_AGENT_BRANCH": "5.25.0",
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},

--- a/release.json
+++ b/release.json
@@ -10,17 +10,6 @@
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	}, 
-	"5.25.0-testnickdeps": {
-		"AGENT_VERSION": "5.26.0",
-		"AGENT_BRANCH": "master",
-		"AGENT6_BRANCH": "master",
-		"INTEGRATIONS_CORE_BRANCH": "master",
-		"TRACE_AGENT_BRANCH": "master",
-		"TRACE_AGENT_ADD_BUILD_VARS": "true",
-		"PROCESS_AGENT_BRANCH": "master",
-		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
-		"OMNIBUS_SOFTWARE_BRANCH": "master"
-	},
 	"5.25.0": {
 		"AGENT_VERSION": "5.25.0",
 		"AGENT_BRANCH": "5.25.0",

--- a/release.json
+++ b/release.json
@@ -10,17 +10,6 @@
 		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},
-	"5.25.0-testnickdeps": {
-		"AGENT_VERSION": "5.26.0",
-		"AGENT_BRANCH": "master",
-		"AGENT6_BRANCH": "master",
-		"INTEGRATIONS_CORE_BRANCH": "master",
-		"TRACE_AGENT_BRANCH": "6.3.0",
-		"TRACE_AGENT_ADD_BUILD_VARS": "true",
-		"PROCESS_AGENT_BRANCH": "5.25.0",
-		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
-		"OMNIBUS_SOFTWARE_BRANCH": "master"
-	},
 	"5.25.0": {
 		"AGENT_VERSION": "5.25.0",
 		"AGENT_BRANCH": "5.25.0",


### PR DESCRIPTION
Changes the locations of the *.yaml files to be pulled from their new location

Changes the dependency handling since we are moving to a static environment. We now install each integration with --no-deps, run a pip-compile on the agent_requirements.in file from datadog_checks_base that list the requirements for all integration and install the reqs of that compiled file.

Remove some seemingly dead code and implement the blacklist for skipping installing non-checks

We were previously doing `pip wheel --no-deps` and then pip install on that wheel. This actually causes the dependencies to still be installed, it just doesn't build the wheel for each dependency. What we want is to actually skip the deps during install, not build. 

Added a dep on pip-tools. We now compile the requirements in the builder instead of relying on them to be in the integration core repo. One benefit here is that we can use environment markers (running pip-compile strips the dep from the output txt if the marker requirement isn't met, so building in the runner allows us to dynamically figure out each dependency for the platform)