### PR TITLE
Blacklist the datadog_checks_tests_helper package

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -32,8 +32,9 @@ end
 
 # Skip installing checks that aren't consumer facing
 blacklist = [
-  'datadog_checks_base',  # namespacing package for wheels (NOT AN INTEGRATION)
-  'datadog_checks_dev',   # developer tooling for working on integrations (NOT AN INTEGRATION)
+  'datadog_checks_base',           # namespacing package for wheels (NOT AN INTEGRATION)
+  'datadog_checks_dev',            # developer tooling for working on integrations (NOT AN INTEGRATION)
+  'datadog_checks_tests_helper',   # Testing and Development package, (NOT AN INTEGRATION)
 ]
 
 python_lib_path = File.join(install_dir, "embedded", "lib", "python2.7", "site-packages")


### PR DESCRIPTION
Blacklist the datadog_checks_tests-helper package from the Agent package. Its only used for running tests and dev, not required for a running agent. 