### PR TITLE
[datadog-metro] wrap go-metro with launcher script

### DIFF
--- a/config/software/datadog-agent.rb
+++ b/config/software/datadog-agent.rb
@@ -66,6 +66,8 @@ build do
     # Use a supervisor conf with go-metro on 64-bit platforms only
     if ohai['kernel']['machine'] == 'x86_64'
       copy 'packaging/supervisor.conf', '/etc/dd-agent/supervisor.conf'
+      copy "#{project.files_path}/datadog-metro/go-metro", "#{install_dir}/bin/go-metro"
+      command "chmod ug+x #{install_dir}/bin/go-metro"
     else
       copy 'packaging/supervisor_32.conf', '/etc/dd-agent/supervisor.conf'
     end

--- a/files/datadog-metro/go-metro
+++ b/files/datadog-metro/go-metro
@@ -1,0 +1,14 @@
+#!/bin/sh
+
+SCRIPT_PATH="$( cd "$(dirname "$0")" ; pwd -P )"
+
+if [ -e /etc/redhat-release ]; then
+    major_version=$(rpm -q --queryformat '%{RELEASE}' rpm | grep -o [[:digit:]]*\$)
+    if [ $major_version -eq "5" ]; then
+        echo "RHEL-based distros <=5 do not support go-metro."
+        sleep 2
+        exit 0
+    fi
+fi
+
+$SCRIPT_PATH/go-metro.bin $@


### PR DESCRIPTION
For a better behavior on RHEL-5 boxes.