### PR TITLE
Remove pywin32 dependency from omnibus

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -14,7 +14,6 @@ if not windows?
 else
   # We use our own supervisor shipped as a py2exe-built executable on Windows...
   # therefore we need py2exe. We also need psutil for our home-made supervisor.
-  dependency 'pywin32'
   dependency 'py2exe'
   dependency 'wmi'
 end


### PR DESCRIPTION
### Motivation

Move toward defining all requirements in `integrations-core` itself rather than the build system

### Additional Notes

https://github.com/DataDog/integrations-core/pull/2322