### PR TITLE
Don't ship openstack_controller

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -34,11 +34,12 @@ else
   default_version integrations_core_branch
 end
 
-# Skip installing checks that aren't consumer facing
+# Skip installing checks that aren't consumer facing/in beta
 blacklist = [
   'datadog_checks_base',           # namespacing package for wheels (NOT AN INTEGRATION)
   'datadog_checks_dev',            # developer tooling for working on integrations (NOT AN INTEGRATION)
   'datadog_checks_tests_helper',   # Testing and Development package, (NOT AN INTEGRATION)
+  'openstack_controller',          # Check currently under active development and in beta
 ]
 
 python_lib_path = File.join(install_dir, "embedded", "lib", "python2.7", "site-packages")


### PR DESCRIPTION
What does this PR do?
Don't ship openstack controller

Motivation
We have a new check based on an existing check with substantial changes. This new check is still under active development and isn't currently ready to be consumer facing as its in an alpha/beta stage at the moment. Lets avoid shipping it while we have a few other breaking changes/updates/fixes in the works.

Additional Notes
Anything else we should know when reviewing?