### PR TITLE
fix packaging of trace & process agent

### DIFF
--- a/config/projects/datadog-agent.rb
+++ b/config/projects/datadog-agent.rb
@@ -92,7 +92,7 @@ package :msi do
   extra_package_dir "#{Omnibus::Config.source_dir()}\\extra_package_files"
   additional_sign_files [
       "#{install_dir}\\bin\\gohai.exe",
-      "#{install_dir}\\bin\\trace-agent.exe",
+      "#{Omnibus::Config.source_dir()}\\datadog-agent\\dd-agent\\dist\\trace-agent.exe",
       "#{install_dir}\\dist\\shell.exe",
       "#{install_dir}\\dist\\agent-manager.exe",
       "#{Omnibus::Config.source_dir()}\\datadog-agent\\dd-agent\\dist\\ddagent.exe"

--- a/config/software/datadog-process-agent.rb
+++ b/config/software/datadog-process-agent.rb
@@ -15,7 +15,7 @@ build do
     url = "https://s3.amazonaws.com/datad0g-process-agent/#{binary}"
     curl_command = "powershell -Command wget -OutFile #{binary} #{url}"
     command curl_command
-    command "mv #{binary} #{install_dir}/bin/#{target_binary}"
+    command "mv #{binary} #{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist/#{target_binary}"
   else
     binary = "process-agent-amd64-#{version}"
     target_binary = "process-agent"

--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -95,6 +95,8 @@ build do
 
    if rhel? # temporary workaround for RHEL 5 build issue with the regular `build -a` command
      command "mv $GOPATH/bin/#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
+   elsif windows?
+     command "mv #{gopath}/bin/#{trace_agent_bin} #{Omnibus::Config.source_dir()}/datadog-agent/dd-agent/dist/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
    else
      command "mv #{gopath}/bin/#{trace_agent_bin} #{install_dir}/bin/#{trace_agent_bin}", :env => env, :cwd => agent_cache_dir
    end

--- a/release.json
+++ b/release.json
@@ -7,7 +7,7 @@
 		"TRACE_AGENT_BRANCH": "master",
 		"TRACE_AGENT_ADD_BUILD_VARS": "true",
 		"PROCESS_AGENT_BRANCH": "master",
-		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
+		"OMNIBUS_RUBY_BRANCH": "db/dont_accept_errors",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},
 	"5.30.0": {

--- a/release.json
+++ b/release.json
@@ -7,7 +7,7 @@
 		"TRACE_AGENT_BRANCH": "master",
 		"TRACE_AGENT_ADD_BUILD_VARS": "true",
 		"PROCESS_AGENT_BRANCH": "master",
-		"OMNIBUS_RUBY_BRANCH": "db/dont_accept_errors",
+		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
 		"OMNIBUS_SOFTWARE_BRANCH": "master"
 	},
 	"5.30.0": {

--- a/resources/datadog-agent/msi/source.wxs.erb
+++ b/resources/datadog-agent/msi/source.wxs.erb
@@ -41,7 +41,7 @@
     <!-- This removes entirely the previous version -->
     <Upgrade Id="$(var.PerUserUpgradeCode)">
         <UpgradeVersion OnlyDetect='no'
-                        Property='PREVIOUSFOUND'
+                        Property='PERUSERPREVIOUSFOUND'
                         Minimum='1.0.0' IncludeMinimum='yes'
                         Maximum="99.99.99.99" IncludeMaximum='no'/>
     </Upgrade>
@@ -208,7 +208,7 @@
               Vital="yes"
               KeyPath="yes"
               DiskId="1"
-              Source="$(var.InstallDir)/bin/trace-agent.exe"/>
+              Source="$(var.DistFiles)/trace-agent.exe"/>
             <ServiceInstall Id="DatadogAPMServiceInstaller"
                             DisplayName="!(loc.ServiceApmDisplayName)"
                             Description="!(loc.ServiceApmDescription)"
@@ -247,7 +247,7 @@
                 Vital="yes"
                 KeyPath="yes"
                 DiskId="1"
-                Source="$(var.InstallDir)/bin/process-agent.exe"/>
+                Source="$(var.DistFiles)/process-agent.exe"/>
             <ServiceInstall Id="DatadogProcessServiceInstaller"
                             DisplayName="!(loc.ServiceProcessDisplayName)"
                             Description="!(loc.ServiceProcessDescription)"


### PR DESCRIPTION
Fixes handling of trace & process.

They were being placed in the `bin` directory prior to packaging, and then getting rolled up in the automatic collection; but they're also explicitly installed (because they're services), so they were getting installed twice.  This was destroying the reference counting.

Parallel A6 fix:  https://github.com/DataDog/datadog-agent/pull/2789
Parallel omnibus fix: https://github.com/DataDog/omnibus-ruby/pull/78