### PR TITLE
[protobuf] Remove from omnibus deps of Agent

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -38,7 +38,6 @@ dependency 'jmxterm'
 
 dependency 'kazoo'
 dependency 'ntplib'
-dependency 'protobuf-py'
 dependency 'psutil'
 dependency 'pyopenssl'
 dependency 'python-consul'


### PR DESCRIPTION
Is installed as binary wheel by integrations software def. See full context in https://github.com/DataDog/datadog-agent/pull/3160