### PR TITLE
Point build to `agent-v5` branches by default

### DIFF
--- a/release.json
+++ b/release.json
@@ -1,14 +1,14 @@
 {
 	"nightly": {
-		"AGENT_VERSION": "5.33.0",
-		"AGENT_BRANCH": "master",
-		"AGENT6_BRANCH": "master",
-		"INTEGRATIONS_CORE_BRANCH": "master",
-		"TRACE_AGENT_BRANCH": "master",
+		"AGENT_VERSION": "5.32.2",
+		"AGENT_BRANCH": "agent-v5",
+		"AGENT6_BRANCH": "agent-v5",
+		"INTEGRATIONS_CORE_BRANCH": "agent-v5",
+		"TRACE_AGENT_BRANCH": "agent-v5",
 		"TRACE_AGENT_ADD_BUILD_VARS": "true",
-		"PROCESS_AGENT_BRANCH": "master",
-		"OMNIBUS_RUBY_BRANCH": "datadog-5.5.0",
-		"OMNIBUS_SOFTWARE_BRANCH": "master"
+		"PROCESS_AGENT_BRANCH": "agent-v5",
+		"OMNIBUS_RUBY_BRANCH": "agent-v5",
+		"OMNIBUS_SOFTWARE_BRANCH": "agent-v5"
 	},
 	"5.32.1": {
 		"AGENT_VERSION": "5.32.1",

--- a/release.json
+++ b/release.json
@@ -1,7 +1,7 @@
 {
 	"nightly": {
 		"AGENT_VERSION": "5.32.2",
-		"AGENT_BRANCH": "agent-v5",
+		"AGENT_BRANCH": "master",
 		"AGENT6_BRANCH": "agent-v5",
 		"INTEGRATIONS_CORE_BRANCH": "agent-v5",
 		"TRACE_AGENT_BRANCH": "agent-v5",


### PR DESCRIPTION
Now that `agent-v5` is the default branch for all Agentv5-related repos (except `dd-agent`, see 414db01 for explanation)