### PR TITLE
Revert "[protobuf] Remove from omnibus deps of Agent"

### DIFF
--- a/config/software/agent-deps.rb
+++ b/config/software/agent-deps.rb
@@ -38,6 +38,7 @@ dependency 'jmxterm'
 
 dependency 'kazoo'
 dependency 'ntplib'
+dependency 'protobuf-py'
 dependency 'psutil'
 dependency 'pyopenssl'
 dependency 'python-consul'


### PR DESCRIPTION
Reverts DataDog/dd-agent-omnibus#361

Reason: we want `master` to contain no other change than what was in the `5.32.x` branch, so that it's still in-sync with `integrations-core`'s `agent-v5` branch. This is the only PR that was in `master` and not in `5.32.x`.