### PR TITLE
[curl] we don't need curl on windows

### DIFF
--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -30,7 +30,8 @@ build do
       godir = windows_safe_path("c:/go110")
       gobin = windows_safe_path("#{godir}/go/bin/go")
       gopath = windows_safe_path("c:/gotmp")
-      curl_command = "powershell -Command wget -OutFile #{goout} #{gourl}"
+      powershell_tls_cmdlet = "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12"
+      dl_command = "powershell -Command #{powershell_tls_cmdlet}; Invoke-WebRequest -Uri #{gourl} -OutFile #{goout}"
 
       agent_cache_dir = windows_safe_path("#{gopath}/src/github.com/DataDog/datadog-agent")
 
@@ -49,7 +50,7 @@ build do
       godir = "/usr/local/go110"
       gobin = "#{godir}/go/bin/go"
       gopath = "#{Omnibus::Config.cache_dir}/src/#{name}"
-      curl_command = "curl #{gourl} -o #{goout}"
+      dl_command = "curl #{gourl} -o #{goout}"
 
       agent_cache_dir = "#{gopath}/src/github.com/DataDog/datadog-agent"
 
@@ -63,7 +64,7 @@ build do
     end
 
    # download go
-   command curl_command
+   command dl_command
 
    delete godir
    mkdir godir
@@ -83,7 +84,8 @@ build do
    if windows?
     mkdir windows_safe_path("#{gopath}/bin")
     dep = windows_safe_path("#{gopath}/bin/dep.exe")
-    command "powershell -Command wget -OutFile #{dep} https://github.com/golang/dep/releases/download/v0.5.0/dep-windows-amd64.exe"
+    dep_uri = "https://github.com/golang/dep/releases/download/v0.5.0/dep-windows-amd64.exe"
+    command "powershell -Command #{powershell_tls_cmdlet}; Invoke-WebRequest -Uri #{dep_uri} -OutFile #{dep}"
     command "#{dep} ensure", :env => env, :cwd => agent_cache_dir
    else
     command "go get -u github.com/golang/dep/cmd/dep", :env => env, :cwd => agent_cache_dir

--- a/config/software/datadog-trace-agent.rb
+++ b/config/software/datadog-trace-agent.rb
@@ -30,6 +30,7 @@ build do
       godir = windows_safe_path("c:/go110")
       gobin = windows_safe_path("#{godir}/go/bin/go")
       gopath = windows_safe_path("c:/gotmp")
+      curl_command = "powershell -Command wget -OutFile #{goout} #{gourl}"
 
       agent_cache_dir = windows_safe_path("#{gopath}/src/github.com/DataDog/datadog-agent")
 
@@ -48,6 +49,7 @@ build do
       godir = "/usr/local/go110"
       gobin = "#{godir}/go/bin/go"
       gopath = "#{Omnibus::Config.cache_dir}/src/#{name}"
+      curl_command = "curl #{gourl} -o #{goout}"
 
       agent_cache_dir = "#{gopath}/src/github.com/DataDog/datadog-agent"
 
@@ -61,7 +63,7 @@ build do
     end
 
    # download go
-   command "curl #{gourl} -o #{goout}"
+   command curl_command
 
    delete godir
    mkdir godir
@@ -81,7 +83,7 @@ build do
    if windows?
     mkdir windows_safe_path("#{gopath}/bin")
     dep = windows_safe_path("#{gopath}/bin/dep.exe")
-    command "curl -sSL https://github.com/golang/dep/releases/download/v0.5.0/dep-windows-amd64.exe -o #{dep}"
+    command "powershell -Command wget -OutFile #{dep} https://github.com/golang/dep/releases/download/v0.5.0/dep-windows-amd64.exe"
     command "#{dep} ensure", :env => env, :cwd => agent_cache_dir
    else
     command "go get -u github.com/golang/dep/cmd/dep", :env => env, :cwd => agent_cache_dir


### PR DESCRIPTION
pycurl is required, but we have a binary wheel for that. The actual curl library is not required. 

For consistency (although these definitions are actually using the builder provided curl, not the embedded one), let's use the powershell native mechanisms for downloading the deps.