### PR TITLE
Add 5.32.5-rc.2 version to the release.json

### DIFF
--- a/release.json
+++ b/release.json
@@ -10,7 +10,7 @@
 		"OMNIBUS_RUBY_BRANCH": "agent-v5",
 		"OMNIBUS_SOFTWARE_BRANCH": "agent-v5"
 	},
-	"5.32.5-rc.1": {
+	"5.32.5-rc.2": {
 		"AGENT_VERSION": "5.32.5",
 		"AGENT_BRANCH": "5.32.5-rc.1",
 		"AGENT6_BRANCH": "agent-v5",


### PR DESCRIPTION
Everything stays the same but branch `agent-v5` of `omnibus-software` has been updated (which makes me think that we can't have reproducible builds of the previous versions, since we pin a moving branch).