### PR TITLE
[pylint] pin lazy-object-proxy. Otherwise we have a failed build on alpine

### DIFF
--- a/config/software/pylint.rb
+++ b/config/software/pylint.rb
@@ -10,5 +10,6 @@ build do
 
   # this pins a dependency of pylint, later versions (up to v3.7.1) are broken.
   pip "install configparser==3.5.0"
+  pip "install lazy-object-proxy==1.3.1"  # newer lazy-object-proxy wheels break on alpine
   pip "install pylint==#{version}"
 end


### PR DESCRIPTION
Alpine builds broken with newer `lazy-object-proxy`, an older version is required. 

Let's pin it here for consistency across all builds.