### PR TITLE
[build] addresses build issues - required for centos + windows builds

### DIFF
--- a/config/software/datadog-agent-integrations.rb
+++ b/config/software/datadog-agent-integrations.rb
@@ -21,6 +21,7 @@ relative_path 'integrations-core'
 
 PIPTOOLS_VERSION = "2.0.2"
 WHEELS_VERSION = "0.30.0"
+PYTEST_RUNNER_VERSION = "5.2"
 # dependencies for pip-tools. If any of these is an agent requirement
 # they will not be uninstalled (ie. six). But keeping the list exhaustive.
 UNINSTALL_PIPTOOLS_DEPS = ['six', 'click', 'first', 'pip-tools']
@@ -83,6 +84,7 @@ build do
     # FIX THIS these dependencies have to be grabbed from somewhere
     all_reqs_file.puts "wheel==#{WHEELS_VERSION} --hash=sha256:e721e53864f084f956f40f96124a74da0631ac13fbbd1ba99e8e2b5e9cafdf64"\
         " --hash=sha256:9515fe0a94e823fd90b08d22de45d7bde57c90edce705b22f5e1ecf7e1b653c8"
+    all_reqs_file.puts "pytest-runner==#{PYTEST_RUNNER_VERSION} --hash=sha256:5534b08b133ef9a5e2c22c7886a8f8508c95bb0b0bdc6cc13214f269c3c70d51"
     all_reqs_file.close
 
     # Set frozen requirements (save to var, and to file)

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -59,7 +59,7 @@ if [ -n "$LOCAL_AGENT_REPO" ]; then
   cd -
 else
   echo "Querying: $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py"
-  curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION'
+  curl -v "$REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py" 2>/dev/null | grep 'JMX_VERSION'
   JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
 echo "FOUND JMX_VERSION: $JMX_VERSION"

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -58,6 +58,8 @@ if [ -n "$LOCAL_AGENT_REPO" ]; then
   JMX_VERSION=$(git show $AGENT_BRANCH:config.py | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
   cd -
 else
+  echo "Querying: $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py"
+  curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION'
   JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
 echo "FOUND JMX_VERSION: $JMX_VERSION"

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -60,7 +60,7 @@ if [ -n "$LOCAL_AGENT_REPO" ]; then
 else
   JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
-export JMX_VERSION
+export JMX_VERSION=$JMX_VERSION
 
 # update ruby omnibus package
 bundle update # Make sure to update to the latest version of omnibus-software

--- a/omnibus_build.sh
+++ b/omnibus_build.sh
@@ -60,6 +60,7 @@ if [ -n "$LOCAL_AGENT_REPO" ]; then
 else
   JMX_VERSION=$(curl -v $REMOTE_AGENT_REPO_RAW/$AGENT_BRANCH/config.py 2>/dev/null | grep 'JMX_VERSION' | cut -f2 -d'=' | tr -d ' "')
 fi
+echo "FOUND JMX_VERSION: $JMX_VERSION"
 export JMX_VERSION=$JMX_VERSION
 
 # update ruby omnibus package


### PR DESCRIPTION
This PR addresses to separate issues that were causing build failures on centos and windows respectively:
- `pytest-runner` dependency pull triggered by `cisco_aci` was failing, requiring a prior manual install of the dependency.
- `dep` having issue checking out the correct revision for `github.com/openshift/api` on windows due to extraneous characters in `master` filenames (`:` to be specific). The workaround is to clone to branch `release-3.9` which contains the correct expected revision, and `dep` will skip the clone letting us get through.