### PR TITLE
[Gemfile] Pin aws deps to ruby 2.2-compatible version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,7 @@ source 'https://rubygems.org'
 gem 'toml-rb', '~> 1.1.2'
 gem 'license_scout', '~> 1.0.0'
 gem 'aws-eventstream', '~> 1.1.1'
+gem 'aws-sigv4', '~> 1.2.4'
 
 # we default if env variable aren't set or set to an empty string
 gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: (if ENV['OMNIBUS_RUBY_BRANCH'].to_s.empty? then 'datadog-5.5.0' else ENV['OMNIBUS_RUBY_BRANCH'] end)

--- a/Gemfile
+++ b/Gemfile
@@ -1,9 +1,10 @@
 source 'https://rubygems.org'
 
-# Those gem are no longer compatible with ruby 2.2.0 in there latest vestion:
+# These gems are no longer compatible with ruby 2.2.0 in their latest versions:
 # we need to pin them
 gem 'toml-rb', '~> 1.1.2'
 gem 'license_scout', '~> 1.0.0'
+gem 'aws-eventstream', '~> 1.1.1'
 
 # we default if env variable aren't set or set to an empty string
 gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: (if ENV['OMNIBUS_RUBY_BRANCH'].to_s.empty? then 'datadog-5.5.0' else ENV['OMNIBUS_RUBY_BRANCH'] end)


### PR DESCRIPTION
Pins `aws-eventstream` and `aws-sigv4` to ruby 2.2-compatible version

Fixes:

```
Installing aws-eventstream 1.2.0
Gem::RuntimeRequirementNotMetError: aws-eventstream requires Ruby version >=
2.3. The current ruby version is 2.2.0.
An error occurred while installing aws-eventstream (1.2.0), and Bundler cannot
continue.
Make sure that `gem install aws-eventstream -v '1.2.0' --source
'https://rubygems.org/'` succeeds before bundling.

In Gemfile:
  omnibus was resolved to 5.5.0, which depends on
    aws-sdk was resolved to 2.11.632, which depends on
      aws-sdk-resources was resolved to 2.11.632, which depends on
        aws-sdk-core was resolved to 2.11.632, which depends on
          aws-sigv4 was resolved to 1.3.0, which depends on
            aws-eventstream
```

(example: https://app.circleci.com/pipelines/github/DataDog/docker-dd-agent-build-deb-x64/587/workflows/405d2403-a9ab-4481-9d9b-4bcc5b589813/jobs/5117)

Since our v5 builders only include ruby 2.2.

Example successful deb build on this branch: https://app.circleci.com/pipelines/github/DataDog/docker-dd-agent-build-deb-x64/593/workflows/a66870ed-c60a-44e5-92e5-7dc877a2fcab/jobs/5123 (related pipeline: https://gitlab.ddbuild.io/DataDog/mars-jenkins-scripts/-/pipelines/5377714)